### PR TITLE
[IE\DML]Implement sub op

### DIFF
--- a/src/tests/BUILD.gn
+++ b/src/tests/BUILD.gn
@@ -187,9 +187,7 @@ source_set("webnn_end2end_tests_sources") {
     "end2end/ReluTests.cpp",
     "end2end/ReshapeTests.cpp",
     "end2end/SoftmaxTests.cpp",
-
-    # Disable to test unimplemented Sub.
-    #"end2end/SubTests.cpp",
+    "end2end/SubTests.cpp",
     "end2end/TransposeTests.cpp",
     "end2end/models/MobileNetV2BatchNormNchw.cpp",
     "end2end/models/MobileNetV2Nchw.cpp",

--- a/src/webnn_native/dml/GraphDML.cpp
+++ b/src/webnn_native/dml/GraphDML.cpp
@@ -680,6 +680,8 @@ namespace webnn_native { namespace dml {
             c = ::dml::Add(a, b);
         } else if (binary->GetType() == op::BinaryOpType::kMul) {
             c = ::dml::Multiply(a, b);
+        } else if (binary->GetType() == op::BinaryOpType::kSub) {
+            c = ::dml::Subtract(a, b);
         } else {
             std::string errorMessage = std::string(" Binary op ") +
                                        OpTypeToString(binary->GetType()) +

--- a/third_party/openvino/ienn/src/ie_model.cpp
+++ b/third_party/openvino/ienn/src/ie_model.cpp
@@ -257,6 +257,10 @@ ie_operand_t* Model::AddBinary(ie_binary_type type,
       binary_node =
           std::make_shared<op::v1::Multiply>(primary_node, secondary_node);
       break;
+    case ie_binary_type::SUB:
+      binary_node =
+          std::make_shared<op::v1::Subtract>(primary_node, secondary_node);
+      break;
     default:
       THROW_IE_EXCEPTION << "The operation isn't supported";
   }


### PR DESCRIPTION
- Linux
out/ie/webnn_end2end_tests --gtest_filter=SubTests.*
Note: Google Test filter = SubTests.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from SubTests
[ RUN      ] SubTests.SubTwoInputs
[       OK ] SubTests.SubTwoInputs (8 ms)
[ RUN      ] SubTests.SubBroadcast
[       OK ] SubTests.SubBroadcast (4 ms)
[----------] 2 tests from SubTests (12 ms total)
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (12 ms total)
[  PASSED  ] 2 tests.

- Windows
out\dml\webnn_end2end_tests
.exe --gtest_filter=SubTests.*
Note: Google Test filter = SubTests.*
[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from SubTests
[ RUN      ] SubTests.SubTwoInputs
[       OK ] SubTests.SubTwoInputs (182 ms)
[ RUN      ] SubTests.SubBroadcast
[       OK ] SubTests.SubBroadcast (46 ms)
[----------] 2 tests from SubTests (228 ms total)
[----------] Global test environment tear-down
[==========] 2 tests from 1 test suite ran. (229 ms total)
[  PASSED  ] 2 tests.

