### PR TITLE
[IE/DML]Implement InstanceNorm

### DIFF
--- a/src/tests/BUILD.gn
+++ b/src/tests/BUILD.gn
@@ -180,6 +180,7 @@ source_set("webnn_end2end_tests_sources") {
     "end2end/ConcatTests.cpp",
     "end2end/Conv2dTests.cpp",
     "end2end/GemmTests.cpp",
+    "end2end/InstanceNormTests.cpp",
     "end2end/LeakyReluTests.cpp",
     "end2end/MatMulTests.cpp",
     "end2end/MulTests.cpp",

--- a/src/tests/end2end/InstanceNormTests.cpp
+++ b/src/tests/end2end/InstanceNormTests.cpp
@@ -1,0 +1,163 @@
+// Copyright 2021 The WebNN-native Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "src/tests/WebnnTest.h"
+
+class InstanceNormTests : public WebnnTest {
+    void SetUp() override {
+        builder = ml::CreateGraphBuilder(GetContext());
+    }
+
+  protected:
+    void CheckInstanceNorm(const std::vector<int32_t>& inputShape,
+                           const std::vector<float>& inputData,
+                           const std::vector<float>& expectedValue,
+                           const ml::InstanceNormOptions* options = nullptr) {
+        const ml::Operand a = utils::BuildInput(builder, "a", inputShape);
+        const ml::Operand b = builder.InstanceNorm(a, options);
+        const ml::Graph graph = utils::AwaitBuild(builder, {{"b", b}});
+        ASSERT_TRUE(graph);
+        const ml::Input input = {inputData.data(), inputData.size() * sizeof(float)};
+        const ml::Result result = utils::AwaitCompute(graph, {{"a", input}}).Get("b");
+        EXPECT_TRUE(utils::CheckShape(result, inputShape));
+        EXPECT_TRUE(utils::CheckValue(result, expectedValue));
+    }
+    ml::GraphBuilder builder;
+};
+
+TEST_F(InstanceNormTests, InstanceNormNchw) {
+    const std::vector<int32_t> inputShape = {1, 2, 1, 3};
+    const std::vector<float> inputData = {-1, 0, 1, 2, 3, 4};
+    const std::vector<float> scaleData = {1.0, 1.5};
+    const ml::Operand scale =
+        utils::BuildConstant(builder, {2}, scaleData.data(), scaleData.size() * sizeof(float));
+    const std::vector<float> biasData = {0, 1};
+    const ml::Operand bias =
+        utils::BuildConstant(builder, {2}, biasData.data(), biasData.size() * sizeof(float));
+    ml::InstanceNormOptions options;
+    options.scale = scale;
+    options.bias = bias;
+    std::vector<float> expectedValue = {-1.2247356, 0., 1.2247356, -0.8371035, 1., 2.8371034};
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+
+    options = {};
+    options.scale = scale;
+    expectedValue = {-1.2247356, 0., 1.2247356, -1.8371035, 0., 1.8371034};
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+
+    options = {};
+    options.bias = bias;
+    expectedValue = {-1.2247356, 0., 1.2247356, -0.2247356, 1., 2.2247356};
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+
+    options = {};
+    expectedValue = {-1.2247356, 0., 1.2247356, -1.2247356, 0., 1.2247356};
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+}
+
+TEST_F(InstanceNormTests, InstanceNormNhwc) {
+    const std::vector<int32_t> inputShape = {1, 1, 3, 2};
+    const std::vector<float> inputData = {-1, 2, 0, 3, 1, 4};
+    const std::vector<float> scaleData = {1.0, 1.5};
+    const ml::Operand scale =
+        utils::BuildConstant(builder, {2}, scaleData.data(), scaleData.size() * sizeof(float));
+    const std::vector<float> biasData = {0, 1};
+    const ml::Operand bias =
+        utils::BuildConstant(builder, {2}, biasData.data(), biasData.size() * sizeof(float));
+    ml::InstanceNormOptions options;
+    options.scale = scale;
+    options.bias = bias;
+    options.layout = ml::InputOperandLayout::Nhwc;
+    std::vector<float> expectedValue = {-1.2247356, -0.8371035, 0., 1., 1.2247356, 2.8371034};
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+
+    options = {};
+    options.scale = scale;
+    options.layout = ml::InputOperandLayout::Nhwc;
+    expectedValue = {-1.2247356, -1.8371035, 0, 0, 1.2247356, 1.8371034};
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+
+    options = {};
+    options.bias = bias;
+    options.layout = ml::InputOperandLayout::Nhwc;
+    expectedValue = {-1.2247356, -0.2247356, 0, 1., 1.2247356, 2.2247356};
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+
+    options = {};
+    options.layout = ml::InputOperandLayout::Nhwc;
+    expectedValue = {-1.2247356, -1.2247356, 0, 0., 1.2247356, 1.2247356};
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+}
+
+TEST_F(InstanceNormTests, InstanceNormWithEpsilon) {
+    const std::vector<int32_t> inputShape = {2, 3, 4, 5};
+    const std::vector<float> inputData = {
+        0.23991525,  -1.3108366,  -0.8056796,  -0.20892623, 0.4869082,   0.68151075,  0.5888935,
+        0.45948547,  -0.88501406, 1.9609013,   0.21517155,  0.7427738,   0.853326,    -1.4071878,
+        -0.29106674, -0.11532243, -0.6716852,  -0.30156505, 0.45744178,  0.25426418,  -2.0593688,
+        -0.6538451,  -0.2512263,  0.406628,    0.60806894,  0.44109958,  0.92832196,  -0.64059025,
+        -1.123297,   0.39360833,  0.25650138,  -1.0688477,  -1.746481,   -1.4138917,  -0.75429744,
+        -0.08158732, 0.38385203,  -0.14610007, 1.0802624,   -0.6336054,  -0.21925186, -0.28690416,
+        2.0004241,   -0.4133636,  -0.68942326, -0.9513434,  -0.14104685, -0.74617624, 1.1912495,
+        -1.8508383,  1.4370863,   1.4129546,   2.4901733,   1.1550623,   -0.6818049,  0.21176137,
+        -0.44371676, -0.26306337, -0.01728541, 0.31616235,  1.4783081,   -0.49589762, 1.5187141,
+        -0.63279223, -0.7817453,  0.5844729,   0.35824686,  0.95782155,  -0.5790926,  -0.11348185,
+        0.07356142,  -0.46691516, 0.00941111,  -0.23862253, -0.38974136, 1.1558224,   -0.51724064,
+        0.27272934,  -0.798853,   0.29123458,  2.239732,    0.11339404,  1.0436004,   -0.38251045,
+        0.5698435,   -1.3686458,  -0.04936051, -0.6490325,  -0.58417344, -0.03446375, -0.7549325,
+        0.3405552,   0.3986468,   0.69191414,  -2.348451,   1.2103504,   -0.33432662, 0.33831024,
+        0.11177547,  -1.9477838,  1.9487013,   0.13771565,  0.32841948,  -0.6585632,  -0.19066776,
+        -1.1357359,  1.3015537,   -0.50085896, -0.14418271, -0.2672549,  1.2022284,   2.2585037,
+        1.3386828,   0.4864522,   -0.17040975, -0.5450272,  -0.0906434,  -0.23216948, -1.6074374,
+        -0.33925202,
+    };
+    const std::vector<float> scaleData = {0.55290383, -1.1786512, -0.12353817};
+    const ml::Operand scale =
+        utils::BuildConstant(builder, {3}, scaleData.data(), scaleData.size() * sizeof(float));
+    const std::vector<float> biasData = {0.36079535, 2.3073995, -0.12267359};
+    const ml::Operand bias =
+        utils::BuildConstant(builder, {3}, biasData.data(), biasData.size() * sizeof(float));
+
+    ml::InstanceNormOptions options;
+    options.scale = scale;
+    options.bias = bias;
+    options.epsilon = 1e-2;
+    std::vector<float> expectedValue = {
+        4.94363964e-01,  -5.80250263e-01, -2.30195075e-01, 1.83333233e-01,  6.65521026e-01,
+        8.00373435e-01,  7.36193061e-01,  6.46518111e-01,  -2.85170883e-01, 1.68694437e+00,
+        4.77217466e-01,  8.42826486e-01,  9.19435143e-01,  -6.47018194e-01, 1.26412854e-01,
+        2.48197228e-01,  -1.37341797e-01, 1.19137913e-01,  6.45101905e-01,  5.04307210e-01,
+        4.69082165e+00,  2.78269839e+00,  2.23610783e+00,  1.34301233e+00,  1.06953847e+00,
+        1.29621410e+00,  6.34766579e-01,  2.76470399e+00,  3.42002106e+00,  1.36068761e+00,
+        1.54682255e+00,  3.34610128e+00,  4.26604843e+00,  3.81452894e+00,  2.91907144e+00,
+        2.00580788e+00,  1.37393284e+00,  2.09338975e+00,  4.28493977e-01,  2.75522137e+00,
+        -7.73530304e-02, -6.95866644e-02, -3.32167834e-01, -5.50693423e-02, -2.33782008e-02,
+        6.68977946e-03,  -8.63308161e-02, -1.68630555e-02, -2.39276052e-01, 1.09950148e-01,
+        -2.67497659e-01, -2.64727384e-01, -3.88390154e-01, -2.35121816e-01, -2.42527649e-02,
+        -1.26832575e-01, -5.15848622e-02, -7.23235458e-02, -1.00538410e-01, -1.38817608e-01,
+        1.43087399e+00,  -8.45769346e-02, 1.46189058e+00,  -1.89660758e-01, -3.04000944e-01,
+        7.44743168e-01,  5.71086287e-01,  1.03133523e+00,  -1.48439497e-01, 2.08975226e-01,
+        3.52554440e-01,  -6.23292625e-02, 3.03311020e-01,  1.12914041e-01,  -3.08865309e-03,
+        1.18332565e+00,  -1.00960344e-01, 5.05440831e-01,  -3.17133218e-01, 5.19645929e-01,
+        -3.07856321e-01, 2.09997821e+00,  1.04662585e+00,  2.66153336e+00,  1.58310151e+00,
+        3.77821898e+00,  2.28427911e+00,  2.96333909e+00,  2.88989353e+00,  2.26741028e+00,
+        3.08325863e+00,  1.84274423e+00,  1.77696204e+00,  1.44487035e+00,  4.88773632e+00,
+        8.57800603e-01,  2.60697079e+00,  1.84528637e+00,  2.10181117e+00,  4.43402672e+00,
+        -3.49317908e-01, -1.20361626e-01, -1.44471616e-01, -1.96910128e-02, -7.88453147e-02,
+        4.06361893e-02,  -2.67501414e-01, -3.96289825e-02, -8.47222507e-02, -6.91626817e-02,
+        -2.54944086e-01, -3.88485104e-01, -2.72195488e-01, -1.64451107e-01, -8.14064592e-02,
+        -3.40449512e-02, -9.14910287e-02, -7.35983998e-02, 1.00271679e-01,  -6.00603521e-02,
+    };
+    CheckInstanceNorm(inputShape, inputData, expectedValue, &options);
+}

--- a/src/tests/end2end/InstanceNormTests.cpp
+++ b/src/tests/end2end/InstanceNormTests.cpp
@@ -26,11 +26,10 @@ class InstanceNormTests : public WebnnTest {
                            const ml::InstanceNormOptions* options = nullptr) {
         const ml::Operand a = utils::BuildInput(builder, "a", inputShape);
         const ml::Operand b = builder.InstanceNorm(a, options);
-        const ml::Graph graph = utils::AwaitBuild(builder, {{"b", b}});
+        const ml::Graph graph = utils::Build(builder, {{"b", b}});
         ASSERT_TRUE(graph);
-        const ml::Input input = {inputData.data(), inputData.size() * sizeof(float)};
-        const ml::Result result = utils::AwaitCompute(graph, {{"a", input}}).Get("b");
-        EXPECT_TRUE(utils::CheckShape(result, inputShape));
+        std::vector<float> result(utils::SizeOfShape(inputShape));
+        utils::Compute(graph, {{"a", inputData}}, {{"b", result}});
         EXPECT_TRUE(utils::CheckValue(result, expectedValue));
     }
     ml::GraphBuilder builder;

--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -127,6 +127,8 @@ source_set("webnn_native_sources") {
     "ops/Gemm.h",
     "ops/Input.cpp",
     "ops/Input.h",
+    "ops/InstanceNorm.cpp",
+    "ops/InstanceNorm.h",
     "ops/LeakyRelu.cpp",
     "ops/LeakyRelu.h",
     "ops/Pad.cpp",

--- a/src/webnn_native/Graph.cpp
+++ b/src/webnn_native/Graph.cpp
@@ -93,6 +93,10 @@ namespace webnn_native {
         UNREACHABLE();
     }
 
+    MaybeError GraphBase::AddInstanceNorm(const op::InstanceNorm* instanceNorm) {
+        return DAWN_UNIMPLEMENTED_ERROR("AddInstanceNorm");
+    }
+
     MaybeError GraphBase::Finish() {
         UNREACHABLE();
     }

--- a/src/webnn_native/Graph.h
+++ b/src/webnn_native/Graph.h
@@ -43,6 +43,7 @@ namespace webnn_native {
         class Concat;
         class Gemm;
         class Clamp;
+        class InstanceNorm;
     }  // namespace op
 
     class GraphBase : public ObjectBase {
@@ -67,6 +68,7 @@ namespace webnn_native {
         virtual MaybeError AddConcat(const op::Concat* concat);
         virtual MaybeError AddGemm(const op::Gemm* gemm);
         virtual MaybeError AddClamp(const op::Clamp* clamp);
+        virtual MaybeError AddInstanceNorm(const op::InstanceNorm* instanceNorm);
         virtual MaybeError Finish();
         virtual MaybeError Compile();
 

--- a/src/webnn_native/GraphBuilder.cpp
+++ b/src/webnn_native/GraphBuilder.cpp
@@ -33,6 +33,7 @@
 #include "webnn_native/ops/Conv2d.h"
 #include "webnn_native/ops/Gemm.h"
 #include "webnn_native/ops/Input.h"
+#include "webnn_native/ops/InstanceNorm.h"
 #include "webnn_native/ops/LeakyRelu.h"
 #include "webnn_native/ops/Pad.h"
 #include "webnn_native/ops/Pool2d.h"
@@ -168,6 +169,11 @@ namespace webnn_native {
                                        OperandBase* padding,
                                        PadOptions const* options) {
         DAWN_VALIDATE_AND_INFER_TYPES(new op::Pad(this, input, padding, options));
+    }
+
+    OperandBase* GraphBuilderBase::InstanceNorm(OperandBase* input,
+                                                InstanceNormOptions const* options) {
+        DAWN_VALIDATE_AND_INFER_TYPES(new op::InstanceNorm(this, input, options));
     }
 
     GraphBase* GraphBuilderBase::Build(NamedOperandsBase const* namedOperands) {

--- a/src/webnn_native/GraphBuilder.h
+++ b/src/webnn_native/GraphBuilder.h
@@ -58,6 +58,7 @@ namespace webnn_native {
                                OperandBase*,
                                OperandBase*,
                                BatchNormOptions const* options);
+        OperandBase* InstanceNorm(OperandBase*, InstanceNormOptions const* options);
         GraphBase* Build(NamedOperandsBase const* namedOperands);
 
       private:

--- a/src/webnn_native/dml/GraphDML.cpp
+++ b/src/webnn_native/dml/GraphDML.cpp
@@ -1144,13 +1144,13 @@ namespace webnn_native { namespace dml {
         if (options->scale == nullptr) {
             std::vector<float> scale(inputDims[1], 1.0);
             expressions.insert(expressions.begin(),
-                               BindingConstant(type, {1, inputDims[1], 1, 1}, scale,
+                               BindingConstant(type, {1, inputDims[1], 1, 1}, scale.data(),
                                                sizeof(float) * inputDims[1]));
         }
         if (options->bias == nullptr) {
             std::vector<float> bias(inputDims[1], 0.0);
-            expressions.push_back(
-                BindingConstant(type, {1, inputDims[1], 1, 1}, bias, sizeof(float) * inputDims[1]));
+            expressions.push_back(BindingConstant(type, {1, inputDims[1], 1, 1}, bias.data(),
+                                                  sizeof(float) * inputDims[1]));
         }
 
         ::dml::Expression output = ::dml::MeanVarianceNormalization(

--- a/src/webnn_native/dml/GraphDML.h
+++ b/src/webnn_native/dml/GraphDML.h
@@ -32,6 +32,7 @@
 #include "webnn_native/ops/Conv2d.h"
 #include "webnn_native/ops/Gemm.h"
 #include "webnn_native/ops/Input.h"
+#include "webnn_native/ops/InstanceNorm.h"
 #include "webnn_native/ops/Pad.h"
 #include "webnn_native/ops/Pool2d.h"
 #include "webnn_native/ops/ReduceMean.h"
@@ -66,6 +67,7 @@ namespace webnn_native { namespace dml {
         virtual MaybeError AddGemm(const op::Gemm* Gemm) override;
         virtual MaybeError AddConcat(const op::Concat* concat) override;
         virtual MaybeError AddClamp(const op::Clamp* clamp) override;
+        virtual MaybeError AddInstanceNorm(const op::InstanceNorm* instanceNorm) override;
         virtual MaybeError Finish() override;
 
       private:

--- a/src/webnn_native/openvino/GraphIE.cpp
+++ b/src/webnn_native/openvino/GraphIE.cpp
@@ -171,6 +171,30 @@ namespace webnn_native { namespace ie {
         return {};
     }
 
+    MaybeError Graph::AddInstanceNorm(const op::InstanceNorm* instanceNorm) {
+        auto inputs = instanceNorm->Inputs();
+        ie_operand_t input;
+        input.name = const_cast<char*>(mOperandIdMap[inputs[0].Get()].c_str());
+        ie_operand_t* ieOperand;
+        ie_instance_norm_options_t ieOptions;
+        auto options = instanceNorm->GetOptions();
+        if (options->scale != nullptr) {
+            ieOptions.scale = {const_cast<char*>(mOperandIdMap[inputs[1].Get()].c_str())};
+        }
+        if (options->bias != nullptr) {
+            size_t biasIndex = options->scale != nullptr ? 2 : 1;
+            ieOptions.bias = {const_cast<char*>(mOperandIdMap[inputs[biasIndex].Get()].c_str())};
+        }
+        ieOptions.epsilon = options->epsilon;
+        ieOptions.layout = static_cast<ie_input_operand_layout>(options->layout);
+
+        IEStatusCode code =
+            IE(ie_model_add_instance_norm)(mIeModel, &input, &ieOptions, &ieOperand);
+        DAWN_TRY(CheckStatusCode(code, "IE add instanceNorm"));
+        mOperandIdMap[instanceNorm] = std::string(ieOperand->name);
+        return {};
+    }
+
     MaybeError Graph::AddBatchNorm(const op::BatchNorm* batchNorm) {
         auto inputs = batchNorm->Inputs();
         ie_operand_t input, mean, variance;

--- a/src/webnn_native/openvino/GraphIE.h
+++ b/src/webnn_native/openvino/GraphIE.h
@@ -32,6 +32,7 @@
 #include "webnn_native/ops/Conv2d.h"
 #include "webnn_native/ops/Gemm.h"
 #include "webnn_native/ops/Input.h"
+#include "webnn_native/ops/InstanceNorm.h"
 #include "webnn_native/ops/LeakyRelu.h"
 #include "webnn_native/ops/Pad.h"
 #include "webnn_native/ops/Pool2d.h"
@@ -64,6 +65,7 @@ namespace webnn_native { namespace ie {
         virtual MaybeError AddUnary(const op::Unary* unary) override;
         virtual MaybeError AddConcat(const op::Concat* concat) override;
         virtual MaybeError AddGemm(const op::Gemm* Gemm) override;
+        virtual MaybeError AddInstanceNorm(const op::InstanceNorm* InstanceNorm) override;
         virtual MaybeError Finish() override;
 
       private:

--- a/src/webnn_native/ops/InstanceNorm.cpp
+++ b/src/webnn_native/ops/InstanceNorm.cpp
@@ -1,0 +1,71 @@
+// Copyright 2021 The WebNN-native Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "webnn_native/ops/InstanceNorm.h"
+
+#include <algorithm>
+
+#include "common/Log.h"
+#include "webnn_native/Error.h"
+
+namespace webnn_native { namespace op {
+    InstanceNorm::InstanceNorm(GraphBuilderBase* builder,
+                               OperandBase* input,
+                               InstanceNormOptions const* options)
+        : OperandBase(builder, {input}) {
+        if (options != nullptr) {
+            mOptions = *options;
+            if (options->scale != nullptr) {
+                mInputs.push_back(options->scale);
+            }
+            if (options->bias != nullptr) {
+                mInputs.push_back(options->bias);
+            }
+        } else {
+            mOptions.scale = nullptr;
+            mOptions.bias = nullptr;
+        }
+    }
+
+    MaybeError InstanceNorm::ValidateAndInferTypes() {
+        MaybeError maybeError = OperandBase::ValidateAndInferTypes();
+        if (maybeError.IsError()) {
+            return maybeError;
+        }
+
+        // The input is 4-D tensor.
+        if (mInputs[0]->Rank() != 4) {
+            return DAWN_VALIDATION_ERROR("Input is not a 4D tensor.");
+        }
+
+        // The scale is 1-D tensor.
+        if (mOptions.scale != nullptr) {
+            auto scale = mInputs[1];
+            if (scale->Rank() != 1) {
+                return DAWN_VALIDATION_ERROR("Argument scale is not a 1D tensor.");
+            }
+        }
+        // The bias is 1-D tensor.
+        if (mOptions.bias != nullptr) {
+            size_t biasIndex = mOptions.scale != nullptr ? 2 : 1;
+            auto bias = mInputs[biasIndex];
+            if (bias->Rank() != 1) {
+                return DAWN_VALIDATION_ERROR("Argument bias is not a 1D tensor.");
+            }
+        }
+
+        return {};
+    }
+
+}}  // namespace webnn_native::op

--- a/src/webnn_native/ops/InstanceNorm.h
+++ b/src/webnn_native/ops/InstanceNorm.h
@@ -1,0 +1,45 @@
+// Copyright 2021 The WebNN-native Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WEBNN_NATIVE_OPS_INSTANCENORM_H_
+#define WEBNN_NATIVE_OPS_INSTANCENORM_H_
+
+#include "webnn_native/Graph.h"
+#include "webnn_native/Operand.h"
+
+namespace webnn_native { namespace op {
+
+    class InstanceNorm final : public OperandBase {
+      public:
+        InstanceNorm(GraphBuilderBase* builder,
+                     OperandBase* input,
+                     InstanceNormOptions const* options);
+        ~InstanceNorm() override = default;
+
+        MaybeError AddToGraph(GraphBase* graph) const override {
+            return graph->AddInstanceNorm(this);
+        }
+        MaybeError ValidateAndInferTypes() override;
+
+        InstanceNormOptions const* GetOptions() const {
+            return &mOptions;
+        }
+
+      private:
+        InstanceNormOptions mOptions;
+    };
+
+}}  // namespace webnn_native::op
+
+#endif  // WEBNN_NATIVE_OPS_INSTANCENORM_H_

--- a/third_party/openvino/ienn/src/ie_model.cpp
+++ b/third_party/openvino/ienn/src/ie_model.cpp
@@ -67,9 +67,10 @@ ie_operand_t* CreateOperand(std::string& name) {
   return operand;
 }
 
+template <typename T>
 ngraph::Output<ngraph::Node> Reshape(
     const ngraph::Output<ngraph::Node>& input_node,
-    const std::vector<size_t>& new_shape) {
+    const std::vector<T>& new_shape) {
   auto target_shape_node = std::make_shared<op::Constant>(
       element::i64, Shape{new_shape.size()}, new_shape);
   auto reshape_node = std::make_shared<op::v1::Reshape>(
@@ -179,14 +180,14 @@ ie_operand_t* Model::AddMatMul(ie_operand_t* a, ie_operand_t* b) {
   // Unsqueeze to 2D by adding axes with size 1 to the left of the shape if
   // first input is equal to 1.
   if (primary_shape.size() == 1) {
-    primary_node = Reshape(primary_node, {1, primary_shape[0]});
+    primary_node = Reshape<size_t>(primary_node, {1, primary_shape[0]});
   }
   auto secondary_node = name_node_map_[b->name];
   auto secondary_shape = secondary_node.get_shape();
   // Unsqueeze to 2D by adding axes with size 1 to the right of the shape if
   // second input is equal to 1.
   if (secondary_shape.size() == 1) {
-    secondary_node = Reshape(secondary_node, {secondary_shape[0], 1});
+    secondary_node = Reshape<size_t>(secondary_node, {secondary_shape[0], 1});
   }
   auto matmul_node = std::make_shared<op::v0::MatMul>(
       primary_node, secondary_node, false, false);
@@ -202,7 +203,7 @@ ie_operand_t* Model::AddMatMul(ie_operand_t* a, ie_operand_t* b) {
   // [3]
   // https://github.com/openvinotoolkit/openvino/blob/master/ngraph/core/src/op/matmul.cpp#L85
   if (primary_shape.size() == 1 && secondary_shape.size() == 1) {
-    auto scalar_node = Reshape(matmul_node->output(0), {1});
+    auto scalar_node = Reshape<size_t>(matmul_node->output(0), {1});
     node_name = scalar_node.get_node()->get_name();
     name_node_map_[node_name] = scalar_node;
   }
@@ -240,12 +241,7 @@ ie_operand_t* Model::AddInstanceNorm(ie_operand_t* input,
   auto variance_node =
       std::make_shared<op::v1::ReduceMean>(power_node, axes_node, true)
           ->output(0);
-
-  const std::vector<int32_t> shape({1, -1, 1, 1});
-  auto target_shape_node =
-      std::make_shared<op::Constant>(element::i64, Shape{shape.size()}, shape);
-  auto reshape_node = std::make_shared<op::v1::Reshape>(
-      scale_node, target_shape_node->output(0), true);
+  auto reshape_node = Reshape<int32_t>(scale_node, {1, -1, 1, 1});
 
   constant_node =
       op::Constant::create(element::f32, Shape{}, {options->epsilon})
@@ -259,8 +255,7 @@ ie_operand_t* Model::AddInstanceNorm(ie_operand_t* input,
       std::make_shared<op::v1::Divide>(sub_node, power_node)->output(0);
   auto mul_node =
       std::make_shared<op::v1::Multiply>(reshape_node, div_node)->output(0);
-  reshape_node = std::make_shared<op::v1::Reshape>(
-      bias_node, target_shape_node->output(0), true);
+  reshape_node = Reshape<int32_t>(bias_node, {1, -1, 1, 1});
 
   auto instance_norm_node =
       std::make_shared<op::v1::Add>(mul_node, reshape_node);

--- a/third_party/openvino/ienn/src/ie_model.h
+++ b/third_party/openvino/ienn/src/ie_model.h
@@ -43,6 +43,8 @@ class Model {
                              ie_operand_t* mean,
                              ie_operand_t* variance,
                              ie_batch_norm_options_t* options);
+  ie_operand_t* AddInstanceNorm(ie_operand_t* input,
+                                ie_instance_norm_options_t* options);
   ie_operand_t* AddBinary(ie_binary_type type,
                           ie_operand_t* a,
                           ie_operand_t* b);

--- a/third_party/openvino/ienn/src/ie_nn_c_api.cpp
+++ b/third_party/openvino/ienn/src/ie_nn_c_api.cpp
@@ -148,6 +148,21 @@ IEStatusCode ie_model_add_batch_norm(ie_model_t* model,
   return IEStatusCode::OK;
 }
 
+IEStatusCode ie_model_add_instance_norm(ie_model_t* model,
+                                        ie_operand_t* input,
+                                        ie_instance_norm_options* options,
+                                        ie_operand_t** operand) {
+  if (model == nullptr || input == nullptr) {
+    return IEStatusCode::GENERAL_ERROR;
+  }
+
+  BEGINE_TRY
+  *operand = model->object->AddInstanceNorm(input, options);
+  END_CATCH
+
+  return IEStatusCode::OK;
+}
+
 IEStatusCode ie_model_add_binary(ie_model_t* model,
                                  ie_binary_type type,
                                  ie_operand_t* a,

--- a/third_party/openvino/ienn/src/ie_nn_c_api.h
+++ b/third_party/openvino/ienn/src/ie_nn_c_api.h
@@ -117,6 +117,13 @@ typedef struct ie_batch_norm_options {
   double epsilon = 1e-5;
 } ie_batch_norm_options_t;
 
+typedef struct ie_instance_norm_options {
+  ie_operand_t scale;
+  ie_operand_t bias;
+  double epsilon = 1e-5;
+  ie_input_operand_layout layout = ie_input_operand_layout::Nchw;
+} ie_instance_norm_options_t;
+
 typedef struct ie_conv2d_options {
   uint32_t paddingCount = 4;
   int32_t const* padding;
@@ -300,6 +307,21 @@ ie_model_add_batch_norm(ie_model_t* model,
                         ie_operand_t* variance,
                         ie_batch_norm_options* options,
                         ie_operand_t** operand);
+
+/**
+ * @brief Add instance_norm node to nGraph. Use the ie_operand_free() method to
+ *  free the operand memory.
+ * @ingroup model
+ * @param ie_operand_t The input operand.
+ * @param ie_operand_t The scale operand.
+ * @param ie_operand_t The bias operand.
+ * @return Status code of the operation: OK(0) for success.
+ */
+NEURAL_NETWORK_C_API(IEStatusCode)
+ie_model_add_instance_norm(ie_model_t* model,
+                           ie_operand_t* input,
+                           ie_instance_norm_options* options,
+                           ie_operand_t** operand);
 
 /**
  * @brief Add binary node to nGraph. Use the ie_operand_free() method to

--- a/webnn.json
+++ b/webnn.json
@@ -288,6 +288,15 @@
       {"name": "epsilon", "type": "float", "default": 1e-5}
     ]
   },
+  "instanceNorm options": {
+  "category": "structure",
+    "members": [
+      {"name": "scale", "type": "operand"},
+      {"name": "bias", "type": "operand"},
+      {"name": "epsilon", "type": "float", "default": 1e-5},
+      {"name": "layout", "type": "input operand layout", "default": "nchw"}
+    ]
+  },
   "graph builder": {
     "category": "object",
     "methods": [
@@ -478,6 +487,14 @@
           {"name": "mean", "type": "operand"},
           {"name": "variance", "type": "operand"},
           {"name": "options", "type": "batchNorm options", "annotation": "const*", "optional": true}
+        ]
+      },
+      {
+        "name": "instance norm",
+        "returns": "operand",
+        "args": [
+          {"name": "input", "type": "operand"},
+          {"name": "options", "type": "instanceNorm options", "annotation": "const*", "optional": true}
         ]
       },
       {


### PR DESCRIPTION
Transferred from @lisa0314 and fixed the issue of IC failure.
Thanks for Mingming's help. @fujunwei @mingmingtasd PTAL, thanks!
Test result:
**[IE]** webnn_end2end_tests --gtest_filter=InstanceNorm*
Note: Google Test filter = InstanceNorm*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from InstanceNormTests
[ RUN      ] InstanceNormTests.InstanceNormNchw
[       OK ] InstanceNormTests.InstanceNormNchw (28 ms)
[ RUN      ] InstanceNormTests.InstanceNormNhwc
[       OK ] InstanceNormTests.InstanceNormNhwc (26 ms)
[ RUN      ] InstanceNormTests.InstanceNormWithEpsilon
[       OK ] InstanceNormTests.InstanceNormWithEpsilon (4 ms)
[----------] 3 tests from InstanceNormTests (58 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (58 ms total)
[  PASSED  ] 3 tests.

**[DML]** webnn_end2end_tests.exe --gtest_filter=InstanceNorm*
Note: Google Test filter = InstanceNorm*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from InstanceNormTests
[ RUN      ] InstanceNormTests.InstanceNormNchw
[       OK ] InstanceNormTests.InstanceNormNchw (130 ms)
[ RUN      ] InstanceNormTests.InstanceNormNhwc
[       OK ] InstanceNormTests.InstanceNormNhwc (123 ms)
[ RUN      ] InstanceNormTests.InstanceNormWithEpsilon
[       OK ] InstanceNormTests.InstanceNormWithEpsilon (25 ms)
[----------] 3 tests from InstanceNormTests (279 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (281 ms total)
[  PASSED  ] 3 tests.