### PR TITLE
Fix the failure for specified output

### DIFF
--- a/node/src/Graph.cpp
+++ b/node/src/Graph.cpp
@@ -156,7 +156,7 @@ namespace node {
     };
 
     template <class T>
-    bool GetNamedResources(const Napi::Value& jsValue, std::map<std::string, T>& namedResources) {
+    bool GetNamedResources(const Napi::Value& jsValue, std::map<std::string, T>& namedResources, std::string type) {
         if (!jsValue.IsObject()) {
             return false;
         }
@@ -177,7 +177,7 @@ namespace node {
             //   sequence<long> dimensions;
             // };
             T resource = {};
-            if (!jsResource.Has("data")) {
+            if (!jsResource.Has("data") && type == "input") {
                 // Input buffer is required.
                 return false;
             }
@@ -227,12 +227,12 @@ namespace node {
         WEBNN_NODE_ASSERT(info.Length() == 1 || info.Length() == 2,
                           "The number of arguments is invalid.");
         std::map<std::string, Input> inputs;
-        WEBNN_NODE_ASSERT(GetNamedResources<Input>(info[0], inputs),
+        WEBNN_NODE_ASSERT(GetNamedResources<Input>(info[0], inputs, "input"),
                           "The inputs parameter is invalid.");
 
         std::map<std::string, Output> outputs;
         if (info.Length() > 1) {
-            WEBNN_NODE_ASSERT(GetNamedResources<Output>(info[1], outputs),
+            WEBNN_NODE_ASSERT(GetNamedResources<Output>(info[1], outputs, "output"),
                               "The outputs parameter is invalid.");
         }
         Napi::Env env = info.Env();
@@ -247,11 +247,11 @@ namespace node {
         // status compute(NamedInputs inputs, NamedOutputs outputs);
         WEBNN_NODE_ASSERT(info.Length() == 2, "The number of arguments is invalid.");
         std::map<std::string, Input> inputs;
-        WEBNN_NODE_ASSERT(GetNamedResources<Input>(info[0], inputs),
+        WEBNN_NODE_ASSERT(GetNamedResources<Input>(info[0], inputs, "input"),
                           "The inputs parameter is invalid.");
 
         std::map<std::string, Output> outputs;
-        WEBNN_NODE_ASSERT(GetNamedResources<Output>(info[1], outputs),
+        WEBNN_NODE_ASSERT(GetNamedResources<Output>(info[1], outputs, "output"),
                           "The outputs parameter is invalid.");
 
         ml::NamedInputs namedInputs = ml::CreateNamedInputs();


### PR DESCRIPTION
It fixes the test case (here)[https://github.com/webmachinelearning/webnn-polyfill/blob/1b7f84ec5d1b6443e10c28a2cb953cbe21cdb9bf/test/api/graph.js#L47]. But I am not sure if the implementation can bring risks about the `webnn-native` C++ implementation.

P.S the commit of the `webnn-polyfill` in the `webnn-native` is not the latest. And I find that the related test case is modified in the latest `webnn-polyfill`. So it needs another check when the `webnn-native` upgrades the commits of `webnn-polyfill`. 