### PR TITLE
Add clang format checking into CI.

### DIFF
--- a/.github/workflows/clang_format_check.yml
+++ b/.github/workflows/clang_format_check.yml
@@ -1,0 +1,34 @@
+name: clang format
+
+on: [push, pull_request]
+
+jobs:
+
+  job:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Git config
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Install depot_tools
+      run: git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git ../depot_tools
+
+    - name: Sync code
+      run: |
+        export PATH=${PWD}/../depot_tools:${PATH}
+        cp scripts/standalone.gclient .gclient
+        gclient sync
+
+    - name: Clang format check
+      run: |
+        export PATH=${PWD}/../depot_tools:${PATH}
+        bash workflow_scripts/clang_format_check.sh

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![clang format](https://github.com/webmachinelearning/webnn-native/actions/workflows/clang_format_check.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/clang_format_check.yml)
 [![null backend](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_null.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_null.yml)
 [![DirectML backend](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml)
 

--- a/workflow_scripts/clang_format_check.sh
+++ b/workflow_scripts/clang_format_check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+echo "Clang format check..."
+git checkout -b workaroundBranchForCI
+git cl format
+DIFF=""
+DIFF=`git diff`
+if [ "$DIFF" == "" ]; then
+  echo "Clang format check: PASS"
+  exit 0
+else
+  echo "Clang format check: FAIL"
+  git diff
+  exit 1
+fi


### PR DESCRIPTION
Please have a preview on format failure sample: https://github.com/BruceDai/webnn-native/runs/3141300499.
And add a new badge for clang format, if format checking passed, the badge is ![clang format](https://github.com/BruceDai/webnn-native/actions/workflows/clang_format_check.yml/badge.svg)

@huningxin PTAL, thanks.