### PR TITLE
Support device selection for C++ examples with -d option

### DIFF
--- a/examples/MobileNetV2/Main.cpp
+++ b/examples/MobileNetV2/Main.cpp
@@ -29,7 +29,8 @@ int main(int argc, const char* argv[]) {
     }
 
     // Create a graph with weights and biases from .npy files.
-    ml::Context context = CreateCppContext();
+    const ml::ContextOptions options = utils::CreateContextOptions(mobilevetv2.mDevice);
+    ml::Context context = CreateCppContext(&options);
     context.SetUncapturedErrorCallback(
         [](MLErrorType type, char const* message, void* userData) {
             if (type != MLErrorType_NoError) {

--- a/examples/MobileNetV2/README.md
+++ b/examples/MobileNetV2/README.md
@@ -15,7 +15,7 @@ Example Options:
     -m "<path>"             Required. Path to the .npy files with trained weights/biases.
     -l "<layout>"           Optional. Specify the layout: "nchw" or "nhwc". The default value is "nchw".
     -n "<integer>"          Optional. Number of iterations. The default value is 1, and should not be less than 1.
-
+    -d "<device>"           Optional. Specify a target device: "cpu" or "gpu" or "default" to infer on. The default value is "default".
 ```
 
 ## Example Output

--- a/examples/ResNet/Main.cpp
+++ b/examples/ResNet/Main.cpp
@@ -29,7 +29,8 @@ int main(int argc, const char* argv[]) {
     }
 
     // Create a graph with weights and biases from .npy files.
-    ml::Context context = CreateCppContext();
+    const ml::ContextOptions options = utils::CreateContextOptions(resnet.mDevice);
+    ml::Context context = CreateCppContext(&options);
     context.SetUncapturedErrorCallback(
         [](MLErrorType type, char const* message, void* userData) {
             if (type != MLErrorType_NoError) {

--- a/examples/ResNet/README.md
+++ b/examples/ResNet/README.md
@@ -15,7 +15,7 @@ Example Options:
     -m "<path>"             Required. Path to the .npy files with trained weights/biases.
     -l "<layout>"           Optional. Specify the layout: "nchw" or "nhwc". The default value is "nchw".
     -n "<integer>"          Optional. Number of iterations. The default value is 1, and should not be less than 1.
-
+    -d "<device>"           Optional. Specify a target device: "cpu" or "gpu" or "default" to infer on. The default value is "default".
 ```
 
 ## Example Output

--- a/examples/SampleUtils.cpp
+++ b/examples/SampleUtils.cpp
@@ -53,11 +53,14 @@ bool ExampleBase::ParseAndCheckExampleOptions(int argc, const char* argv[]) {
             mLayout = argv[i + 1];
         } else if (strcmp("-n", argv[i]) == 0 && i + 1 < argc) {
             mNIter = atoi(argv[i + 1]);
+        } else if (strcmp("-d", argv[i]) == 0 && i + 1 < argc) {
+            mDevice = argv[i + 1];
+            transform(mDevice.begin(), mDevice.end(), mDevice.begin(), ::tolower);
         }
     }
 
     if (mImagePath.empty() || mWeightsPath.empty() || (mLayout != "nchw" && mLayout != "nhwc") ||
-        mNIter < 1) {
+        mNIter < 1 || (mDevice != "gpu" && mDevice != "cpu" && mDevice != "default")) {
         dawn::ErrorLog() << "Invalid options.";
         utils::ShowUsage();
         return false;
@@ -240,6 +243,10 @@ namespace utils {
                   << "Optional. Number of iterations. The default value is 1, and should not be "
                      "less than 1."
                   << std::endl;
+        std::cout << "    -d \"<device>\"           "
+                  << "Optional. Specify a target device: \"cpu\" or \"gpu\" or "
+                     "\"default\" to infer on. The default value is \"default\"."
+                  << std::endl;
     }
 
     void PrintExexutionTime(std::vector<TIME_TYPE> executionTime) {
@@ -256,4 +263,18 @@ namespace utils {
         }
     }
 
+    const ml::ContextOptions CreateContextOptions(const std::string& device) {
+        ml::ContextOptions options;
+        if (device == "cpu") {
+            options.devicePreference = ml::DevicePreference::Cpu;
+        } else if (device == "gpu") {
+            options.devicePreference = ml::DevicePreference::Gpu;
+        } else if (device == "default") {
+            options.devicePreference = ml::DevicePreference::Default;
+        } else {
+            dawn::ErrorLog()
+                << "Invalid options, only support devices: \"cpu\", \"gpu\" and \"default\".";
+        }
+        return options;
+    }
 }  // namespace utils

--- a/examples/SampleUtils.h
+++ b/examples/SampleUtils.h
@@ -48,6 +48,7 @@ class ExampleBase {
     std::vector<float> mStd = {1, 1, 1};   // Variance values of pixels on channels.
     std::string mChannelScheme = "RGB";
     std::vector<int32_t> mOutputShape;
+    std::string mDevice = "default";
 };
 
 ml::Context CreateCppContext(ml::ContextOptions const* options = nullptr);
@@ -240,6 +241,8 @@ namespace utils {
 
     void PrintExexutionTime(
         std::vector<std::chrono::duration<double, std::milli>> executionTimeVector);
+
+    const ml::ContextOptions CreateContextOptions(const std::string& device = "default");
 }  // namespace utils
 
 #endif  // WEBNN_NATIVE_EXAMPLES_SAMPLE_UTILS_H_

--- a/examples/SqueezeNet/Main.cpp
+++ b/examples/SqueezeNet/Main.cpp
@@ -29,7 +29,8 @@ int main(int argc, const char* argv[]) {
     }
 
     // Create a graph with weights and biases from .npy files.
-    ml::Context context = CreateCppContext();
+    const ml::ContextOptions options = utils::CreateContextOptions(squeezenet.mDevice);
+    ml::Context context = CreateCppContext(&options);
     context.SetUncapturedErrorCallback(
         [](MLErrorType type, char const* message, void* userData) {
             if (type != MLErrorType_NoError) {

--- a/examples/SqueezeNet/README.md
+++ b/examples/SqueezeNet/README.md
@@ -15,7 +15,7 @@ Example Options:
     -m "<path>"             Required. Path to the .npy files with trained weights/biases.
     -l "<layout>"           Optional. Specify the layout: "nchw" or "nhwc". The default value is "nchw".
     -n "<integer>"          Optional. Number of iterations. The default value is 1, and should not be less than 1.
-
+    -d "<device>"           Optional. Specify a target device: "cpu" or "gpu" or "default" to infer on. The default value is "default".
 ```
 
 ## Example Output

--- a/src/tests/End2EndTestsMain.cpp
+++ b/src/tests/End2EndTestsMain.cpp
@@ -23,20 +23,7 @@ int main(int argc, char** argv) {
             transform(device.begin(), device.end(), device.begin(), ::tolower);
         }
     }
-
-    ml::ContextOptions options;
-    if (device == "cpu") {
-        options.devicePreference = ml::DevicePreference::Cpu;
-    } else if (device == "gpu") {
-        options.devicePreference = ml::DevicePreference::Gpu;
-    } else if (device == "default") {
-        options.devicePreference = ml::DevicePreference::Default;
-    } else {
-        dawn::ErrorLog()
-            << "Invalid device options, only support \"cpu\", \"gpu\" and \"default\".";
-        return -1;
-    }
-
+    const ml::ContextOptions options = utils::CreateContextOptions(device);
     InitWebnnEnd2EndTestEnvironment(&options);
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Now we can run C++ examples on a target device by -d cpu/gpu/default. PTAL, thanks! @huningxin 