### PR TITLE
add the powerPreference for CreateContext for node binding

### DIFF
--- a/node/src/ML.cpp
+++ b/node/src/ML.cpp
@@ -15,6 +15,7 @@
 #include "ML.h"
 
 #include "Context.h"
+#include "Utils.h"
 
 Napi::FunctionReference node::ML::constructor;
 
@@ -24,8 +25,15 @@ namespace node {
     }
 
     Napi::Value ML::CreateContext(const Napi::CallbackInfo& info) {
-        Napi::Object context = Context::constructor.New({});
-        return context;
+        WEBNN_NODE_ASSERT(info.Length() <= 1, "The number of arguments is invalid.");
+
+        Napi::Object context;
+        std::vector<napi_value> args = {};
+        if (info.Length() > 0) {
+            WEBNN_NODE_ASSERT(info[0].IsObject(), "The option should be an object");
+            args.push_back(info[0].As<Napi::Object>());
+        }
+        return Context::constructor.New(args);
     }
 
     Napi::Object ML::Initialize(Napi::Env env, Napi::Object exports) {


### PR DESCRIPTION
Add the `powerPreference` option for Context. It resolves the two failed cases [failed case 1](https://github.com/webmachinelearning/webnn-polyfill/blob/7d33b3c62918cd4dab1753446086c9d3261b691a/test/api/context.js#L36)  and [failed case 2](https://github.com/webmachinelearning/webnn-polyfill/blob/7d33b3c62918cd4dab1753446086c9d3261b691a/test/api/context.js#L40).