### PR TITLE
Fix the build error on Linux

### DIFF
--- a/third_party/openvino/ngraph_c_api/build_ngraph_c_api_unix.sh
+++ b/third_party/openvino/ngraph_c_api/build_ngraph_c_api_unix.sh
@@ -87,6 +87,7 @@ fi
 cp "$build_dir/$OS_PATH/Release/lib/libngraph_c_api.so" "$WEBNN_NATIVE_LIB_PATH"
 mkdir -p "$WEBNN_NATIVE_LIB_PATH/inference_engine/include/"
 mkdir -p "$WEBNN_NATIVE_LIB_PATH/inference_engine/lib/intel64/"
+mkdir -p "$WEBNN_NATIVE_LIB_PATH/inference_engine/lib/intel64/Release"
 yes | cp -rf "$INTEL_OPENVINO_DIR/inference_engine/include/c_api" "$WEBNN_NATIVE_LIB_PATH/inference_engine/include/c_api"
 yes | cp "$INTEL_OPENVINO_DIR/inference_engine/lib/intel64/libinference_engine_c_api.so" "$WEBNN_NATIVE_LIB_PATH/inference_engine/lib/intel64/Release"
 


### PR DESCRIPTION
On the Linux environment, the `libinference_engine_c_api.so` in openvino can not be moved to the target path successfully. This PR fixes the corresponding error.