### PR TITLE
Missing include for building tests

### DIFF
--- a/src/common/BUILD.gn
+++ b/src/common/BUILD.gn
@@ -49,6 +49,7 @@ config("dawn_internal") {
     "${target_gen_dir}/../../src",
     "${webnn_root}/src",
     "${webnn_dawn_root}/src",
+    "${webnn_root}",
   ]
 
   defines = []


### PR DESCRIPTION
Include paths in `src/test` are being specified from WebNN's root directory (ex. `src/examples`, `src/third_party`, etc) which means we must also specify `${webnn_root}` in the common `BUILD.gn` config to build tests under third_party.

