### PR TITLE
Add CI for testing OpenVINO backend on Linux platform.

### DIFF
--- a/.github/workflows/build_test_openvino_linux.yml
+++ b/.github/workflows/build_test_openvino_linux.yml
@@ -1,0 +1,103 @@
+name: OpenVINO backend (Linux)
+
+on: [push, pull_request]
+
+jobs:
+
+  job:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Git config
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - name: Install depot_tools
+      run: |
+        git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git ../depot_tools
+        export PATH=$PWD/../depot_tools:$PATH
+        gclient
+
+    - name: Install OpenVINO Toolkit
+      run: |
+        export version="2021.4.582"
+        wget https://registrationcenter-download.intel.com/akdlm/irc_nas/17988/l_openvino_toolkit_p_${version}.tgz
+        tar -xvzf l_openvino_toolkit_p_${version}.tgz
+        cd l_openvino_toolkit_p_${version}
+        sudo ./install.sh -s --install_dir /opt/intel --accept_eula
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - uses: actions/checkout@v2
+      with:
+        ref: main
+        path: baseline
+        fetch-depth: 0
+
+    - name: Sync code for main branch
+      run: |
+        export PATH=$PWD/../depot_tools:$PATH
+        cd baseline
+        cp scripts/standalone.gclient .gclient
+        gclient sync
+
+    - name: Generate project for main branch
+      run: |
+        export PATH=$PWD/../depot_tools:$PATH
+        cd baseline
+        gn gen out/Release --args="webnn_enable_openvino=true is_debug=false"
+
+    - name: Build for main branch
+      run: |
+        export PATH=$PWD/../depot_tools:$PATH
+        cd baseline
+        ninja -C out/Release
+
+    - name: Test for main branch
+      run: |
+        cd baseline
+        echo "Run End2End Tests..."
+        source /opt/intel/openvino_2021/bin/setupvars.sh
+        ./out/Release/webnn_end2end_tests --gtest_output=json:${{ github.workspace }}/../baseline_end2endtests.json  || true
+        cd ..
+        rm -rf baseline
+
+    - uses: actions/checkout@v2
+      with:
+        path: update
+        fetch-depth: 0
+
+    - name: Sync latest code
+      run: |
+        export PATH=$PWD/../depot_tools:$PATH
+        cd update
+        cp scripts/standalone.gclient .gclient
+        gclient sync
+
+    - name: Generate project for update branch
+      run: |
+        export PATH=$PWD/../depot_tools:$PATH
+        cd update
+        gn gen out/Release --args="webnn_enable_openvino=true is_debug=false"
+
+    - name: Build for update branch
+      run: |
+        export PATH=$PWD/../depot_tools:$PATH
+        cd update
+        ninja -C out/Release
+
+    - name: Test for update branch
+      run: |
+        cd update
+        echo "Run End2End Tests..."
+        source /opt/intel/openvino_2021/bin/setupvars.sh
+        ./out/Release/webnn_end2end_tests --gtest_output=json:${{ github.workspace }}/../update_end2endtests.json || true
+
+    - name: Regression check
+      run: |
+        echo "Regression checking..."
+        python update/workflow_scripts/regression_check.py ${{ github.workspace }}/../baseline_end2endtests.json ${{ github.workspace }}/../update_end2endtests.json

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![null backend](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_null.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_null.yml)
 [![DirectML backend](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml)
 [![Node Binding (DirectML backend)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_dml.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_dml.yml)
+[![OpenVINO backend (Linux)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_openvino_linux.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_openvino_linux.yml)
 
 # WebNN-native
 


### PR DESCRIPTION
This PR is for CI checking OpenVINO backend with OpenVINO Toolkit of version 2021.4.582 on Linux platform.
The new badge is ![OpenVINO backend (Linux)](https://github.com/BruceDai/webnn-native/actions/workflows/build_test_openvino_linux.yml/badge.svg).

@huningxin PTAL, thanks. 