### PR TITLE
Support optional object in webnn.json

### DIFF
--- a/generator/templates/webnn_native/webnn_structs.h
+++ b/generator/templates/webnn_native/webnn_structs.h
@@ -24,6 +24,8 @@ namespace webnn_native {
 {% macro render_cpp_default_value(member) -%}
     {%- if member.annotation in ["*", "const*", "const*const*"] and member.optional -%}
         {{" "}}= nullptr
+    {%- elif member.type.category == "object" and member.optional -%}
+        {{" "}}= nullptr
     {%- elif member.type.category in ["enum", "bitmask"] and member.default_value != None -%}
         {{" "}}= ml::{{as_cppType(member.type.name)}}::{{as_cppEnum(Name(member.default_value))}}
     {%- elif member.type.category == "native" and member.default_value != None -%}

--- a/webnn.json
+++ b/webnn.json
@@ -200,8 +200,8 @@
   "clamp options": {
     "category": "structure",
     "members": [
-      {"name": "min value", "type": "operand"},
-      {"name": "max value", "type": "operand"}
+      {"name": "min value", "type": "operand", "optional": true},
+      {"name": "max value", "type": "operand", "optional": true}
     ]
   },
   "conv2d options": {
@@ -217,8 +217,8 @@
       {"name": "groups", "type": "int32_t", "default": 1},
       {"name": "input layout", "type": "input operand layout", "default": "nchw"},
       {"name": "filter layout", "type": "filter operand layout", "default": "oihw"},
-      {"name": "bias", "type": "operand"},
-      {"name": "activation", "type": "operator"}
+      {"name": "bias", "type": "operand", "optional": true},
+      {"name": "activation", "type": "operator", "optional": true}
     ]
   },
   "pad options": {
@@ -287,18 +287,18 @@
   "batchNorm options": {
     "category": "structure",
     "members": [
-      {"name": "scale", "type": "operand"},
-      {"name": "bias", "type": "operand"},
+      {"name": "scale", "type": "operand", "optional": true},
+      {"name": "bias", "type": "operand", "optional": true},
       {"name": "axis", "type": "uint32_t", "default": 1},
       {"name": "epsilon", "type": "float", "default": 1e-5},
-      {"name": "activation", "type": "operator"}
+      {"name": "activation", "type": "operator", "optional": true}
     ]
   },
   "instanceNorm options": {
   "category": "structure",
     "members": [
-      {"name": "scale", "type": "operand"},
-      {"name": "bias", "type": "operand"},
+      {"name": "scale", "type": "operand", "optional": true},
+      {"name": "bias", "type": "operand", "optional": true},
       {"name": "epsilon", "type": "float", "default": 1e-5},
       {"name": "layout", "type": "input operand layout", "default": "nchw"}
     ]


### PR DESCRIPTION
fix #61

The generated `webnn_structs_autogen.h` sets nullptr to optional object pointer:
```c++
    struct BatchNormOptions {
        OperandBase* scale = nullptr;
        OperandBase* bias = nullptr;
        uint32_t axis = 1;
        float epsilon = 1e-05;
        OperatorBase* activation = nullptr;
    };

    struct ClampOptions {
        OperandBase* minValue = nullptr;
        OperandBase* maxValue = nullptr;
    };

    struct Conv2dOptions {
        uint32_t paddingCount = 0;
        int32_t const * padding = nullptr;
        uint32_t stridesCount = 0;
        int32_t const * strides = nullptr;
        uint32_t dilationsCount = 0;
        int32_t const * dilations = nullptr;
        ml::AutoPad autoPad = ml::AutoPad::Explicit;
        int32_t groups = 1;
        ml::InputOperandLayout inputLayout = ml::InputOperandLayout::Nchw;
        ml::FilterOperandLayout filterLayout = ml::FilterOperandLayout::Oihw;
        OperandBase* bias = nullptr;
        OperatorBase* activation = nullptr;
    };

    struct GemmOptions {
        OperandBase* c = nullptr;
        float alpha = 1.0;
        float beta = 1.0;
        bool aTranspose = false;
        bool bTranspose = false;
    };

    struct InstanceNormOptions {
        OperandBase* scale = nullptr;
        OperandBase* bias = nullptr;
        float epsilon = 1e-05;
        ml::InputOperandLayout layout = ml::InputOperandLayout::Nchw;
    };
```

@mingmingtasd @fujunwei, PTAL. Thanks!