### PR TITLE
Updated two badges for DirectML backend with explicit "Windows" characters.

### DIFF
--- a/.github/workflows/build_test_dml.yml
+++ b/.github/workflows/build_test_dml.yml
@@ -1,4 +1,4 @@
-name: DirectML backend
+name: DirectML backend (Windows)
 
 on: [push, pull_request]
 

--- a/.github/workflows/build_test_node_dml.yml
+++ b/.github/workflows/build_test_node_dml.yml
@@ -1,4 +1,4 @@
-name: Node Binding (DirectML backend)
+name: Node Binding (DirectML backend / Windows)
 
 on: [push, pull_request]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![clang format](https://github.com/webmachinelearning/webnn-native/actions/workflows/clang_format_check.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/clang_format_check.yml)
 [![null backend](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_null.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_null.yml)
-[![DirectML backend](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml)
-[![Node Binding (DirectML backend)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_dml.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_dml.yml)
+[![DirectML backend (Windows)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml)
+[![Node Binding (DirectML backend / Windows)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_dml.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_dml.yml)
 [![OpenVINO backend (Linux)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_openvino_linux.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_openvino_linux.yml)
 
 # WebNN-native


### PR DESCRIPTION
Here're updated badges:
![DirectML backend (Windows)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_dml.yml/badge.svg) ![Node Binding (DirectML backend / Windows)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_dml.yml/badge.svg)
@huningxin PTAL, thanks.

I suggest you could merge this one first, after this pr launched, I will continue to fix conflict for #91 with removing last empty commit, thanks.