### PR TITLE
Add bash script for testing by OpenVINO backend on Windows.

### DIFF
--- a/workflow_scripts/test_by_openvino_windows.bat
+++ b/workflow_scripts/test_by_openvino_windows.bat
@@ -1,0 +1,13 @@
+@echo off
+set TARGET=%1
+echo Setup OpenVINO environment...
+call "C:\Program Files (x86)\Intel\openvino_2021\bin\setupvars.bat"
+IF "%2" == "node" (
+echo Run node tests by OpenVINO backend on Windows platform...
+call cd %TARGET%\node
+call npm run report || true
+) ELSE (
+echo Run WebNN End2End tests by OpenVINO backend on Windows platform...
+call cd %TARGET%
+call out\Release\webnn_end2end_tests.exe --gtest_output=json:..\..\%TARGET%_end2endtests.json
+)


### PR DESCRIPTION
This PR is to add a bash script with a workaround of OpenVINO environment setup for testing OpenVINO backend on Windows since OpenVINO environment couldn't be setup by GitHub Actions's step of running OpenVINO **setupvar.bat** directly likes:

```yaml
    - name: Setup OpenVINO environment
      shell: cmd
      run: |
          "C:\Program Files (x86)\Intel\openvino_2021\bin\setupvars.bat"
```

