### PR TITLE
Add CI for Node Binding with WebNN native by OpenVINO backend on Windows platform.

### DIFF
--- a/.github/workflows/build_test_node_openvino_windows.yml
+++ b/.github/workflows/build_test_node_openvino_windows.yml
@@ -1,0 +1,158 @@
+name: Node Binding (OpenVINO backend / Windows)
+
+on: [push, pull_request]
+
+jobs:
+
+  job:
+    runs-on: windows-latest
+    env:
+      OPENVINO_VERSION: 2021.4.582
+
+    steps:
+    - name: Git config
+      run: |
+        git config --global core.autocrlf false
+        git config --global core.eol lf
+
+    - name: Install depot_tools
+      shell: cmd
+      run: |
+        git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git ..\depot_tools
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        gclient
+
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Download OpenVINO Toolkit
+      shell: pwsh
+      run: |
+        Import-Module BitsTransfer
+        Start-BitsTransfer -Source https://registrationcenter-download.intel.com/akdlm/irc_nas/17987/w_openvino_toolkit_p_${{ env.OPENVINO_VERSION }}.exe -Destination w_openvino_toolkit_p_${{ env.OPENVINO_VERSION }}.exe
+
+    - name: Install OpenVINO Toolkit
+      shell: cmd
+      run: |
+        .\w_openvino_toolkit_p_${{ env.OPENVINO_VERSION }}.exe --s --f temp --r yes --a install --eula=accept --output=install_status.txt
+        "C:\Program Files (x86)\Intel\openvino_2021\bin\setupvars.bat"
+
+    - uses: actions/checkout@v2
+      with:
+        ref: main
+        path: baseline
+        fetch-depth: 0
+
+    - name: Sync code for main branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd baseline
+        copy scripts\standalone.gclient .gclient
+        gclient sync
+
+    - name: Generate project for main branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd baseline
+        gn gen out\Release --args="webnn_enable_openvino=true is_debug=false"
+
+    - name: Build for main branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd baseline
+        ninja -C out\Release
+
+    - name: Run 'npm install' command under node folder of main branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%CD%\baseline\out\Release;%PATH%"
+        cd baseline\node
+        npm install --webnn_native_lib_path="../out/Release"
+
+    - name: Run 'npm run build' command under node folder of main branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%CD%\baseline\out\Release;%PATH%"
+        cd baseline\node
+        npm run build --webnn_native_lib_path="../out/Release"
+
+    - name: Run node test for main branch
+      shell: cmd
+      run: |
+        baseline\workflow_scripts\test_by_openvino_windows.bat baseline node || true
+
+    - name: Prepare baseline result file for regression checking
+      shell: cmd
+      run: |
+        echo "Baseline node test result:"
+        type baseline\node\result.xml
+        copy baseline\node\result.xml ${{ github.workspace }}\..\baseline.xml
+
+    - uses: actions/checkout@v2
+      with:
+        path: update
+        fetch-depth: 0
+
+    - name: Sync latest code
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd update
+        copy scripts\standalone.gclient .gclient
+        gclient sync
+
+    - name: Generate project for update branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd update
+        gn gen out\Release --args="webnn_enable_openvino=true is_debug=false"
+
+    - name: Build for update branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%PATH%"
+        set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
+        cd update
+        ninja -C out\Release
+
+    - name: Run 'npm install' command under node folder of update branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%CD%\update\out\Release;%PATH%"
+        cd update\node
+        npm install --webnn_native_lib_path="../out/Release"
+
+    - name: Run 'npm run build' command under node folder of update branch
+      shell: cmd
+      run: |
+        set "PATH=%CD%\..\depot_tools;%CD%\update\out\Release;%PATH%"
+        cd update\node
+        npm run build --webnn_native_lib_path="../out/Release"
+
+    - name: Run node test for update branch
+      shell: cmd
+      run: |
+        update\workflow_scripts\test_by_openvino_windows.bat update node || true
+
+    - name: Prepare latest result file for regression checking
+      shell: cmd
+      run: |
+        echo "Latest node test result:"
+        type update\node\result.xml
+        copy update\node\result.xml ${{ github.workspace }}\..\update.xml
+
+    - name: Regression check
+      run: |
+        echo "Regression checking..."
+        python update\workflow_scripts\regression_check.py ${{ github.workspace }}\..\baseline.xml ${{ github.workspace }}\..\update.xml

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![OpenVINO backend (Linux)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_openvino_linux.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_openvino_linux.yml)
 [![Node Binding (OpenVINO backend / Linux)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_openvino_linux.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_openvino_linux.yml)
 [![OpenVINO backend (Windows)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_openvino_windows.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_openvino_windows.yml)
+[![Node Binding (OpenVINO backend / Windows)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_openvino_windows.yml/badge.svg)](https://github.com/webmachinelearning/webnn-native/actions/workflows/build_test_node_openvino_windows.yml)
 
 # WebNN-native
 


### PR DESCRIPTION
Please have a preview on the [link](https://github.com/BruceDai/webnn-native/runs/3408450764?check_suite_focus=true).
This new badge is ![Node Binding (OpenVINO backend / Windows)](https://github.com/BruceDai/webnn-native/actions/workflows/build_test_node_openvino_windows.yml/badge.svg).

@huningxin PTAL, thanks.