### PR TITLE
Fix issue to print out detailed error messages when failing to add ops

### DIFF
--- a/src/tests/WebnnTest.cpp
+++ b/src/tests/WebnnTest.cpp
@@ -62,7 +62,7 @@ void WebnnTest::ErrorCallback(MLErrorType type, char const* message, void* userd
         ASSERT_FALSE(self->mError) << "Got two errors in expect block";
         self->mError = true;
     } else {
-        ASSERT_TRUE(type != MLErrorType_NoError) << "Got unexpected error: " << message;
+        ASSERT_TRUE(type == MLErrorType_NoError) << "Got unexpected error: " << message;
     }
 }
 


### PR DESCRIPTION
Fix #84 to get useful error log from [ValidateAndInferTypes()](https://github.com/webmachinelearning/webnn-native/blob/main/src/webnn_native/ops/Conv2d.cpp#L76) for each ops. PTAL, thanks! @fujunwei 