### PR TITLE
Fix WebNN test only builds due to missing DirectML.dll.

### DIFF
--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -234,6 +234,8 @@ source_set("webnn_native_sources") {
       "-Wno-logical-not-parentheses",
       "-Wno-macro-redefined",
     ]
+
+    data_deps += [ ":copy_dml_dll" ]
   }
 
   if (webnn_enable_onednn) {


### PR DESCRIPTION
Building the WebNN E2E test target will fail to run because of the missing DML DLL binary in the output build directory that is only copied when the whole project gets built. To fix, the DirectML.dll dependency is specified as a data_deps for the webnn_native_sources build target.

This fix should also resolve https://github.com/webmachinelearning/webnn-native/issues/124 once merged.

@fujunwei @huningxin 