### PR TITLE
Generate model paths for end2end tests at build.

### DIFF
--- a/src/tests/BUILD.gn
+++ b/src/tests/BUILD.gn
@@ -156,6 +156,17 @@ source_set("webnn_end2end_tests_sources") {
   configs += [ "${webnn_root}/src/common:dawn_internal" ]
   testonly = true
 
+  _models_folder_relative_path =
+      "../../node/third_party/webnn-polyfill/test-data/models/"
+
+  _data_path = rebase_path(_models_folder_relative_path, webnn_root)
+  _webnn_root_data_path =
+      get_path_info("${webnn_root}" + "${_data_path}", "dir")
+  _models_folder_absolute_path = rebase_path(_webnn_root_data_path)
+
+  defines =
+      [ "WEBNN_END2END_TEST_MODEL_PATH=\"${_models_folder_absolute_path}\"" ]
+
   deps = [
     ":gmock_and_gtest",
     "${webnn_root}/examples:webnn_sample_utils",

--- a/src/tests/end2end/models/MobileNetV2BatchNormNchw.cpp
+++ b/src/tests/end2end/models/MobileNetV2BatchNormNchw.cpp
@@ -15,6 +15,8 @@
 #include "examples/MobileNetV2/MobileNetV2.h"
 #include "src/tests/WebnnTest.h"
 
+static const std::string kModelPath = WEBNN_END2END_TEST_MODEL_PATH;
+
 class MobileNetV2BatchNormNchwTests : public WebnnTest {
   public:
     void TestMobileNetV2Nchw(const std::string& inputFile,
@@ -22,8 +24,7 @@ class MobileNetV2BatchNormNchwTests : public WebnnTest {
                              bool fused = true) {
         MobileNetV2 mobilenetv2;
         mobilenetv2.mFused = fused;
-        const std::string nchwPath =
-            "node/third_party/webnn-polyfill/test-data/models/mobilenetv2_batchnorm_nchw/";
+        const std::string nchwPath = kModelPath + "/mobilenetv2_batchnorm_nchw/";
         mobilenetv2.mWeightsPath = nchwPath + "weights/";
         const ml::GraphBuilder builder = ml::CreateGraphBuilder(GetContext());
         ml::Operand output = mobilenetv2.LoadBatchNormNCHW(builder, false);

--- a/src/tests/end2end/models/MobileNetV2Nchw.cpp
+++ b/src/tests/end2end/models/MobileNetV2Nchw.cpp
@@ -15,6 +15,8 @@
 #include "examples/MobileNetV2/MobileNetV2.h"
 #include "src/tests/WebnnTest.h"
 
+static const std::string kModelPath = WEBNN_END2END_TEST_MODEL_PATH;
+
 class MobileNetV2NchwTests : public WebnnTest {
   public:
     void TestMobileNetV2Nchw(const std::string& inputFile,
@@ -22,8 +24,7 @@ class MobileNetV2NchwTests : public WebnnTest {
                              bool fused = true) {
         MobileNetV2 mobilenetv2;
         mobilenetv2.mFused = fused;
-        const std::string nchwPath =
-            "node/third_party/webnn-polyfill/test-data/models/mobilenetv2_nchw/";
+        const std::string nchwPath = kModelPath + "/mobilenetv2_nchw/";
         mobilenetv2.mWeightsPath = nchwPath + "weights/";
         const ml::GraphBuilder builder = ml::CreateGraphBuilder(GetContext());
         ml::Operand output = mobilenetv2.LoadNCHW(builder, false);

--- a/src/tests/end2end/models/MobileNetV2Nhwc.cpp
+++ b/src/tests/end2end/models/MobileNetV2Nhwc.cpp
@@ -15,6 +15,8 @@
 #include "examples/MobileNetV2/MobileNetV2.h"
 #include "src/tests/WebnnTest.h"
 
+static const std::string kModelPath = WEBNN_END2END_TEST_MODEL_PATH;
+
 class MobileNetV2NhwcTests : public WebnnTest {
   public:
     void TestMobileNetV2Nhwc(const std::string& inputFile,
@@ -22,8 +24,7 @@ class MobileNetV2NhwcTests : public WebnnTest {
                              bool fused = true) {
         MobileNetV2 mobilenetv2;
         mobilenetv2.mFused = fused;
-        const std::string nhwcPath =
-            "node/third_party/webnn-polyfill/test-data/models/mobilenetv2_nhwc/";
+        const std::string nhwcPath = kModelPath + "/mobilenetv2_nhwc/";
         mobilenetv2.mWeightsPath = nhwcPath + "weights/";
         mobilenetv2.mLayout = "nhwc";
         const ml::GraphBuilder builder = ml::CreateGraphBuilder(GetContext());

--- a/src/tests/end2end/models/ResNetNchw.cpp
+++ b/src/tests/end2end/models/ResNetNchw.cpp
@@ -15,6 +15,8 @@
 #include "examples/ResNet/ResNet.h"
 #include "src/tests/WebnnTest.h"
 
+static const std::string kModelPath = WEBNN_END2END_TEST_MODEL_PATH;
+
 class ResNetNchwTests : public WebnnTest {
   public:
     void TestResNetNchw(const std::string& inputFile,
@@ -22,8 +24,7 @@ class ResNetNchwTests : public WebnnTest {
                         bool fused = true) {
         ResNet resnet;
         resnet.mFused = fused;
-        const std::string nchwPath =
-            "node/third_party/webnn-polyfill/test-data/models/resnet50v2_nchw/";
+        const std::string nchwPath = kModelPath + "/resnet50v2_nchw/";
         resnet.mWeightsPath = nchwPath + "weights/";
         const ml::GraphBuilder builder = ml::CreateGraphBuilder(GetContext());
         ml::Operand output = resnet.LoadNCHW(builder, false);

--- a/src/tests/end2end/models/ResNetNhwc.cpp
+++ b/src/tests/end2end/models/ResNetNhwc.cpp
@@ -15,6 +15,8 @@
 #include "examples/ResNet/ResNet.h"
 #include "src/tests/WebnnTest.h"
 
+static const std::string kModelPath = WEBNN_END2END_TEST_MODEL_PATH;
+
 class ResNetNhwcTests : public WebnnTest {
   public:
     void TestResNetNhwc(const std::string& inputFile,
@@ -22,8 +24,7 @@ class ResNetNhwcTests : public WebnnTest {
                         bool fused = true) {
         ResNet resnet;
         resnet.mFused = fused;
-        const std::string nhwcPath =
-            "node/third_party/webnn-polyfill/test-data/models/resnet101v2_nhwc/";
+        const std::string nhwcPath = kModelPath + "/resnet101v2_nhwc/";
         resnet.mWeightsPath = nhwcPath + "weights/";
         const ml::GraphBuilder builder = ml::CreateGraphBuilder(GetContext());
         ml::Operand output = resnet.LoadNHWC(builder, false);

--- a/src/tests/end2end/models/SqueezeNetNchw.cpp
+++ b/src/tests/end2end/models/SqueezeNetNchw.cpp
@@ -15,6 +15,8 @@
 #include "examples/SqueezeNet/SqueezeNet.h"
 #include "src/tests/WebnnTest.h"
 
+static const std::string kModelPath = WEBNN_END2END_TEST_MODEL_PATH;
+
 class SqueezeNetNchwTests : public WebnnTest {
   public:
     void TestSqueezeNetNchw(const std::string& inputFile,
@@ -22,8 +24,7 @@ class SqueezeNetNchwTests : public WebnnTest {
                             bool fused = true) {
         SqueezeNet squeezenet;
         squeezenet.mFused = fused;
-        const std::string nchwPath =
-            "node/third_party/webnn-polyfill/test-data/models/squeezenet1.1_nchw/";
+        const std::string nchwPath = kModelPath + "/squeezenet1.1_nchw/";
         squeezenet.mWeightsPath = nchwPath + "weights/";
         const ml::GraphBuilder builder = ml::CreateGraphBuilder(GetContext());
         ml::Operand output = squeezenet.LoadNCHW(builder, false);

--- a/src/tests/end2end/models/SqueezeNetNhwc.cpp
+++ b/src/tests/end2end/models/SqueezeNetNhwc.cpp
@@ -15,6 +15,8 @@
 #include "examples/SqueezeNet/SqueezeNet.h"
 #include "src/tests/WebnnTest.h"
 
+static const std::string kModelPath = WEBNN_END2END_TEST_MODEL_PATH;
+
 class SqueezeNetNhwcTests : public WebnnTest {
   public:
     void TestSqueezeNetNhwc(const std::string& inputFile,
@@ -22,8 +24,7 @@ class SqueezeNetNhwcTests : public WebnnTest {
                             bool fused = true) {
         SqueezeNet squeezenet;
         squeezenet.mFused = fused;
-        const std::string nhwcPath =
-            "node/third_party/webnn-polyfill/test-data/models/squeezenet1.0_nhwc/";
+        const std::string nhwcPath = kModelPath + "/squeezenet1.0_nhwc/";
         squeezenet.mWeightsPath = nhwcPath + "weights/";
         squeezenet.mLayout = "nhwc";
         const ml::GraphBuilder builder = ml::CreateGraphBuilder(GetContext());


### PR DESCRIPTION
When webnn_native gets built under .\third_party, the model paths
are incorrectly specified as always being relative to webnn_root (ex. ."\node\").

This PR specifies the model directory using an absolute path so the E2E tests can run under third_party/webnn_native without failure.

@huningxin @fujunwei 