### PR TITLE
Support calculating the output shape of all ops

### DIFF
--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -107,6 +107,8 @@ source_set("webnn_native_sources") {
     "NamedInputs.h",
     "NamedOutputs.h",
     "NamedRecords.h",
+    "NativeUtils.cpp",
+    "NativeUtils.h",
     "ObjectBase.cpp",
     "ObjectBase.h",
     "Operand.cpp",

--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -107,14 +107,14 @@ source_set("webnn_native_sources") {
     "NamedInputs.h",
     "NamedOutputs.h",
     "NamedRecords.h",
-    "NativeUtils.cpp",
-    "NativeUtils.h",
     "ObjectBase.cpp",
     "ObjectBase.h",
     "Operand.cpp",
     "Operand.h",
     "Operator.cpp",
     "Operator.h",
+    "Utils.cpp",
+    "Utils.h",
   ]
 
   sources += [

--- a/src/webnn_native/GraphBuilder.cpp
+++ b/src/webnn_native/GraphBuilder.cpp
@@ -49,22 +49,22 @@
 #include "webnn_native/ops/Transpose.h"
 #include "webnn_native/ops/Unary.h"
 
-#define DAWN_VALIDATE(ptr, objectBase)                 \
-    Ref<OperatorBase> op = AcquireRef(ptr);            \
-    if (GetContext()->ConsumedError(op->Validate())) { \
-        return objectBase::MakeError(this);            \
-    }                                                  \
-    for (;;)                                           \
+#define WEBNN_VALIDATE(ptr, objectBase)                                  \
+    Ref<OperatorBase> op = AcquireRef(ptr);                              \
+    if (GetContext()->ConsumedError(op->ValidateAndInferOutputInfo())) { \
+        return objectBase::MakeError(this);                              \
+    }                                                                    \
+    for (;;)                                                             \
     break
 
-#define VALIDATE_FOR_OPERAND(ptr)    \
-    DAWN_VALIDATE(ptr, OperandBase); \
+#define VALIDATE_FOR_OPERAND(ptr)     \
+    WEBNN_VALIDATE(ptr, OperandBase); \
     return op->PrimaryOutput()
-#define VALIDATE_FUSED_OPERATOR(ptr)  \
-    DAWN_VALIDATE(ptr, OperatorBase); \
+#define VALIDATE_FUSED_OPERATOR(ptr)   \
+    WEBNN_VALIDATE(ptr, OperatorBase); \
     return op.Detach()
-#define VALIDATE_ARRAY_OPERAND(ptr)       \
-    DAWN_VALIDATE(ptr, OperandArrayBase); \
+#define VALIDATE_ARRAY_OPERAND(ptr)        \
+    WEBNN_VALIDATE(ptr, OperandArrayBase); \
     return new OperandArrayBase(this, op->Outputs())
 
 namespace webnn_native {

--- a/src/webnn_native/NativeUtils.cpp
+++ b/src/webnn_native/NativeUtils.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021 The WebNN-native Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "webnn_native/NativeUtils.h"
+
+#include "common/Assert.h"
+
+namespace webnn_native {
+    void ComputeImplicitPaddingForAutoPad(ml::AutoPad autoPad,
+                                          int32_t dilation,
+                                          int32_t inputSize,
+                                          int32_t filterSize,
+                                          int32_t stride,
+                                          int32_t& paddingBegin,
+                                          int32_t& paddingEnd) {
+        int32_t outSize = (inputSize + stride - 1) / stride;
+        int32_t dilatedFilter = (filterSize - 1) * dilation + 1;
+        int32_t neededInput = (outSize - 1) * stride + dilatedFilter;
+        int32_t totalPadding = neededInput > inputSize ? neededInput - inputSize : 0;
+        switch (autoPad) {
+            case ml::AutoPad::SameUpper:
+                paddingBegin = totalPadding / 2;
+                paddingEnd = (totalPadding + 1) / 2;
+                break;
+            case ml::AutoPad::SameLower:
+                paddingBegin = (totalPadding + 1) / 2;
+                paddingEnd = totalPadding / 2;
+                break;
+            default:
+                DAWN_UNREACHABLE();
+        }
+    }
+}  // namespace webnn_native

--- a/src/webnn_native/NativeUtils.h
+++ b/src/webnn_native/NativeUtils.h
@@ -9,30 +9,22 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "webnn_native/Operand.h"
+#ifndef WEBNN_NATIVE_NATIVEUTILS_H_
+#define WEBNN_NATIVE_NATIVEUTILS_H_
 
-#include "common/Assert.h"
-#include "webnn_native/GraphBuilder.h"
+#include <webnn/webnn_cpp.h>
 
 namespace webnn_native {
-
-    OperandBase::OperandBase(GraphBuilderBase* graphBuilder, OperatorBase* operatorBase)
-        : ObjectBase(graphBuilder->GetContext()),
-          mOperator(operatorBase),
-          mType(ml::OperandType::Float32) {
-    }
-
-    OperandBase::OperandBase(GraphBuilderBase* graphBuilder, ObjectBase::ErrorTag tag)
-        : ObjectBase(graphBuilder->GetContext(), tag) {
-    }
-
-    // static
-    OperandBase* OperandBase::MakeError(GraphBuilderBase* GraphBuilder) {
-        return new OperandBase(GraphBuilder, ObjectBase::kError);
-    }
-
+    void ComputeImplicitPaddingForAutoPad(ml::AutoPad autoPad,
+                                          int32_t dilation,
+                                          int32_t inputSize,
+                                          int32_t filterSize,
+                                          int32_t stride,
+                                          int32_t& paddingBegin,
+                                          int32_t& paddingEnd);
 }  // namespace webnn_native
+
+#endif  // WEBNN_NATIVE_OPERATOR_H_

--- a/src/webnn_native/Operand.cpp
+++ b/src/webnn_native/Operand.cpp
@@ -28,9 +28,8 @@ namespace webnn_native {
           mRank(0) {
         if (mOperator->Inputs().size() >= 1) {
             auto primaryInput = mOperator->Inputs()[0];
-            // The type and rank is the same as input[0] by default.
+            // The type is the same as input[0] by default.
             mType = primaryInput->Type();
-            mRank = primaryInput->Rank();
         }
     }
 

--- a/src/webnn_native/Operand.h
+++ b/src/webnn_native/Operand.h
@@ -41,11 +41,13 @@ namespace webnn_native {
         void SetType(ml::OperandType type) {
             mType = type;
         }
-        uint32_t Rank() const {
-            return mRank;
+
+        std::vector<int32_t> Shape() const {
+            return mShape;
         }
-        void SetRank(uint32_t rank) {
-            mRank = rank;
+
+        void SetShape(std::vector<int32_t> shape) {
+            mShape = shape;
         }
 
         static OperandBase* MakeError(GraphBuilderBase* modelBuilder);
@@ -60,6 +62,8 @@ namespace webnn_native {
         ml::OperandType mType;
         // only set rank for dimensions
         uint32_t mRank;
+        // The operand dimensions
+        std::vector<int32_t> mShape;
     };
 }  // namespace webnn_native
 

--- a/src/webnn_native/Operand.h
+++ b/src/webnn_native/Operand.h
@@ -47,7 +47,7 @@ namespace webnn_native {
         }
 
         void SetShape(std::vector<int32_t> shape) {
-            mShape = shape;
+            mShape = std::move(shape);
         }
 
         static OperandBase* MakeError(GraphBuilderBase* modelBuilder);
@@ -60,8 +60,6 @@ namespace webnn_native {
         Ref<OperatorBase> mOperator;
         // The operand type.
         ml::OperandType mType;
-        // only set rank for dimensions
-        uint32_t mRank;
         // The operand dimensions
         std::vector<int32_t> mShape;
     };

--- a/src/webnn_native/Operator.cpp
+++ b/src/webnn_native/Operator.cpp
@@ -63,6 +63,16 @@ namespace webnn_native {
         return {};
     }
 
+    MaybeError OperatorBase::CalculateShape() {
+        if (mInputs.empty()) {
+            return {};
+        }
+        for (auto& output : mOutputs) {
+            output->SetShape(mInputs[0]->Shape());
+        }
+        return {};
+    }
+
     FusedOperator OperatorBase::GetFusedOperator() const {
         return mFusedOperator;
     }
@@ -70,5 +80,34 @@ namespace webnn_native {
     // static
     OperatorBase* OperatorBase::MakeError(GraphBuilderBase* graphBuilder) {
         return new OperatorBase(graphBuilder, ObjectBase::kError);
+    }
+
+    void ComputeImplicitPaddingForAutoPad(ml::AutoPad autoPad,
+                                          int32_t dilation,
+                                          int32_t inputSize,
+                                          int32_t filterSize,
+                                          int32_t stride,
+                                          std::vector<int32_t>& padding) {
+        int32_t outSize = (inputSize + stride - 1) / stride;
+        int32_t dilatedFilter = (filterSize - 1) * dilation + 1;
+        int32_t neededInput = (outSize - 1) * stride + dilatedFilter;
+        int32_t totalPadding = neededInput > inputSize ? neededInput - inputSize : 0;
+        int32_t paddingBegin = 0;
+        int32_t paddingEnd = 0;
+        switch (autoPad) {
+            case ml::AutoPad::SameUpper:
+                paddingBegin = totalPadding / 2;
+                paddingEnd = (totalPadding + 1) / 2;
+                break;
+            case ml::AutoPad::SameLower:
+                paddingBegin = (totalPadding + 1) / 2;
+                paddingEnd = totalPadding / 2;
+                break;
+            default:
+                DAWN_ASSERT(0);
+                break;
+        }
+        padding.push_back(paddingBegin);
+        padding.push_back(paddingEnd);
     }
 }  // namespace webnn_native

--- a/src/webnn_native/Operator.h
+++ b/src/webnn_native/Operator.h
@@ -45,6 +45,7 @@ namespace webnn_native {
         // Add the operand to model for specific backend.
         virtual MaybeError AddToGraph(GraphBase* graph) const;
         virtual MaybeError Validate();
+        virtual MaybeError CalculateShape();
         FusedOperator GetFusedOperator() const;
 
         static OperatorBase* MakeError(GraphBuilderBase* graphBuilder);
@@ -59,6 +60,13 @@ namespace webnn_native {
         // The output operands of operator.
         std::vector<Ref<OperandBase>> mOutputs;
     };
+
+    void ComputeImplicitPaddingForAutoPad(ml::AutoPad autoPad,
+                                          int32_t dilation,
+                                          int32_t inputSize,
+                                          int32_t filterSize,
+                                          int32_t stride,
+                                          std::vector<int32_t>& padding);
 
 }  // namespace webnn_native
 

--- a/src/webnn_native/Operator.h
+++ b/src/webnn_native/Operator.h
@@ -44,8 +44,7 @@ namespace webnn_native {
 
         // Add the operand to model for specific backend.
         virtual MaybeError AddToGraph(GraphBase* graph) const;
-        virtual MaybeError Validate();
-        virtual MaybeError CalculateShape();
+        virtual MaybeError ValidateAndInferOutputInfo();
         FusedOperator GetFusedOperator() const;
 
         static OperatorBase* MakeError(GraphBuilderBase* graphBuilder);
@@ -60,14 +59,6 @@ namespace webnn_native {
         // The output operands of operator.
         std::vector<Ref<OperandBase>> mOutputs;
     };
-
-    void ComputeImplicitPaddingForAutoPad(ml::AutoPad autoPad,
-                                          int32_t dilation,
-                                          int32_t inputSize,
-                                          int32_t filterSize,
-                                          int32_t stride,
-                                          std::vector<int32_t>& padding);
-
 }  // namespace webnn_native
 
 #endif  // WEBNN_NATIVE_OPERATOR_H_

--- a/src/webnn_native/Utils.cpp
+++ b/src/webnn_native/Utils.cpp
@@ -9,22 +9,37 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef WEBNN_NATIVE_NATIVEUTILS_H_
-#define WEBNN_NATIVE_NATIVEUTILS_H_
+#include "webnn_native/Utils.h"
 
-#include <webnn/webnn_cpp.h>
+#include "common/Assert.h"
 
-namespace webnn_native {
+namespace webnn_native { namespace utils {
     void ComputeImplicitPaddingForAutoPad(ml::AutoPad autoPad,
                                           int32_t dilation,
                                           int32_t inputSize,
                                           int32_t filterSize,
                                           int32_t stride,
                                           int32_t& paddingBegin,
-                                          int32_t& paddingEnd);
-}  // namespace webnn_native
-
-#endif  // WEBNN_NATIVE_OPERATOR_H_
+                                          int32_t& paddingEnd) {
+        int32_t outSize = (inputSize + stride - 1) / stride;
+        int32_t dilatedFilter = (filterSize - 1) * dilation + 1;
+        int32_t neededInput = (outSize - 1) * stride + dilatedFilter;
+        int32_t totalPadding = neededInput > inputSize ? neededInput - inputSize : 0;
+        switch (autoPad) {
+            case ml::AutoPad::SameUpper:
+                paddingBegin = totalPadding / 2;
+                paddingEnd = (totalPadding + 1) / 2;
+                break;
+            case ml::AutoPad::SameLower:
+                paddingBegin = (totalPadding + 1) / 2;
+                paddingEnd = totalPadding / 2;
+                break;
+            default:
+                DAWN_UNREACHABLE();
+        }
+    }
+}}  // namespace webnn_native::utils

--- a/src/webnn_native/Utils.h
+++ b/src/webnn_native/Utils.h
@@ -9,37 +9,22 @@
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "webnn_native/NativeUtils.h"
+#ifndef WEBNN_NATIVE_NATIVEUTILS_H_
+#define WEBNN_NATIVE_NATIVEUTILS_H_
 
-#include "common/Assert.h"
+#include <webnn/webnn_cpp.h>
 
-namespace webnn_native {
+namespace webnn_native { namespace utils {
     void ComputeImplicitPaddingForAutoPad(ml::AutoPad autoPad,
                                           int32_t dilation,
                                           int32_t inputSize,
                                           int32_t filterSize,
                                           int32_t stride,
                                           int32_t& paddingBegin,
-                                          int32_t& paddingEnd) {
-        int32_t outSize = (inputSize + stride - 1) / stride;
-        int32_t dilatedFilter = (filterSize - 1) * dilation + 1;
-        int32_t neededInput = (outSize - 1) * stride + dilatedFilter;
-        int32_t totalPadding = neededInput > inputSize ? neededInput - inputSize : 0;
-        switch (autoPad) {
-            case ml::AutoPad::SameUpper:
-                paddingBegin = totalPadding / 2;
-                paddingEnd = (totalPadding + 1) / 2;
-                break;
-            case ml::AutoPad::SameLower:
-                paddingBegin = (totalPadding + 1) / 2;
-                paddingEnd = totalPadding / 2;
-                break;
-            default:
-                DAWN_UNREACHABLE();
-        }
-    }
-}  // namespace webnn_native
+                                          int32_t& paddingEnd);
+}}  // namespace webnn_native::utils
+
+#endif  // WEBNN_NATIVE_OPERATOR_H_

--- a/src/webnn_native/dml/GraphDML.cpp
+++ b/src/webnn_native/dml/GraphDML.cpp
@@ -21,7 +21,7 @@
 #include "webnn_native/ErrorData.h"
 #include "webnn_native/NamedInputs.h"
 #include "webnn_native/NamedOutputs.h"
-#include "webnn_native/NativeUtils.h"
+#include "webnn_native/Utils.h"
 #include "webnn_native/dml/ContextDML.h"
 #include "webnn_native/dml/deps/src/precomp.h"
 
@@ -365,10 +365,12 @@ namespace webnn_native { namespace dml {
             ::dml::TensorDimensions inputDims = input.GetOutputDesc().sizes;
             // {paddingTop, paddingBottom, paddingLeft, paddingRight}
             int32_t paddingTop, paddingBottom, paddingLeft, paddingRight;
-            ComputeImplicitPaddingForAutoPad(options->autoPad, dilations[0], inputDims[2],
-                                             filterSize[0], strides[0], paddingTop, paddingBottom);
-            ComputeImplicitPaddingForAutoPad(options->autoPad, dilations[1], inputDims[3],
-                                             filterSize[1], strides[1], paddingLeft, paddingRight);
+            utils::ComputeImplicitPaddingForAutoPad(options->autoPad, dilations[0], inputDims[2],
+                                                    filterSize[0], strides[0], paddingTop,
+                                                    paddingBottom);
+            utils::ComputeImplicitPaddingForAutoPad(options->autoPad, dilations[1], inputDims[3],
+                                                    filterSize[1], strides[1], paddingLeft,
+                                                    paddingRight);
             return {static_cast<const uint32_t>(paddingTop),
                     static_cast<const uint32_t>(paddingBottom),
                     static_cast<const uint32_t>(paddingLeft),

--- a/src/webnn_native/onednn/GraphDNNL.cpp
+++ b/src/webnn_native/onednn/GraphDNNL.cpp
@@ -21,8 +21,8 @@
 #include "webnn_native/ErrorData.h"
 #include "webnn_native/NamedInputs.h"
 #include "webnn_native/NamedOutputs.h"
-#include "webnn_native/NativeUtils.h"
 #include "webnn_native/Operand.h"
+#include "webnn_native/Utils.h"
 
 #define FAILED(status) (((dnnl_status_t)(status)) != dnnl_success)
 
@@ -672,10 +672,12 @@ namespace webnn_native { namespace onednn {
         int32_t paddingRight = options->padding[3];
 
         if (options->autoPad != ml::AutoPad::Explicit) {
-            ComputeImplicitPaddingForAutoPad(options->autoPad, options->dilations[0], inputDims[2],
-                                             filterDims[2], strides[0], paddingTop, paddingBottom);
-            ComputeImplicitPaddingForAutoPad(options->autoPad, options->dilations[1], inputDims[3],
-                                             filterDims[3], strides[1], paddingLeft, paddingRight);
+            utils::ComputeImplicitPaddingForAutoPad(options->autoPad, options->dilations[0],
+                                                    inputDims[2], filterDims[2], strides[0],
+                                                    paddingTop, paddingBottom);
+            utils::ComputeImplicitPaddingForAutoPad(options->autoPad, options->dilations[1],
+                                                    inputDims[3], filterDims[3], strides[1],
+                                                    paddingLeft, paddingRight);
         }
 
         std::vector<dnnl_dim_t> padding_l = {paddingTop, paddingLeft};

--- a/src/webnn_native/ops/BatchNorm.cpp
+++ b/src/webnn_native/ops/BatchNorm.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 
-#include "common/Log.h"
 #include "webnn_native/Error.h"
 
 namespace webnn_native { namespace op {
@@ -42,8 +41,8 @@ namespace webnn_native { namespace op {
         mActivation = Ref<OperatorBase>(mOptions.activation);
     }
 
-    MaybeError BatchNorm::Validate() {
-        MaybeError maybeError = OperatorBase::Validate();
+    MaybeError BatchNorm::ValidateAndInferOutputInfo() {
+        MaybeError maybeError = OperatorBase::ValidateAndInferOutputInfo();
         if (maybeError.IsError()) {
             return maybeError;
         }
@@ -83,10 +82,9 @@ namespace webnn_native { namespace op {
         if (mOptions.axis != 1 && mOptions.axis != 3) {
             return DAWN_VALIDATION_ERROR("Argument axis is not supported.");
         }
-        maybeError = CalculateShape();
-        if (maybeError.IsError()) {
-            return maybeError;
-        }
+
+        mOutputs[0]->SetShape(mInputs[0]->Shape());
+
         return {};
     }
 

--- a/src/webnn_native/ops/BatchNorm.cpp
+++ b/src/webnn_native/ops/BatchNorm.cpp
@@ -49,24 +49,24 @@ namespace webnn_native { namespace op {
         }
 
         // The input is 4-D tensor.
-        if (mInputs[0]->Rank() != 4) {
+        if (mInputs[0]->Shape().size() != 4) {
             return DAWN_VALIDATION_ERROR("Input is not a 4D tensor.");
         }
 
         // The mean is 1-D tensor.
         auto mean = mInputs[1];
-        if (mean->Rank() != 1) {
+        if (mean->Shape().size() != 1) {
             return DAWN_VALIDATION_ERROR("Argument mean is not a 1D tensor.");
         }
         // The variance is 1-D tensor.
         auto variance = mInputs[2];
-        if (variance->Rank() != 1) {
+        if (variance->Shape().size() != 1) {
             return DAWN_VALIDATION_ERROR("Argument variance is not a 1D tensor.");
         }
         // The scale is 1-D tensor.
         if (mOptions.scale != nullptr) {
             auto scale = mInputs[3];
-            if (scale->Rank() != 1) {
+            if (scale->Shape().size() != 1) {
                 return DAWN_VALIDATION_ERROR("Argument scale is not a 1D tensor.");
             }
         }
@@ -74,7 +74,7 @@ namespace webnn_native { namespace op {
         if (mOptions.bias != nullptr) {
             size_t biasIndex = mOptions.scale != nullptr ? 4 : 3;
             auto bias = mInputs[biasIndex];
-            if (bias->Rank() != 1) {
+            if (bias->Shape().size() != 1) {
                 return DAWN_VALIDATION_ERROR("Argument bias is not a 1D tensor.");
             }
         }
@@ -83,7 +83,10 @@ namespace webnn_native { namespace op {
         if (mOptions.axis != 1 && mOptions.axis != 3) {
             return DAWN_VALIDATION_ERROR("Argument axis is not supported.");
         }
-
+        maybeError = CalculateShape();
+        if (maybeError.IsError()) {
+            return maybeError;
+        }
         return {};
     }
 

--- a/src/webnn_native/ops/BatchNorm.h
+++ b/src/webnn_native/ops/BatchNorm.h
@@ -33,7 +33,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddBatchNorm(this);
         }
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
         BatchNormOptions const* GetOptions() const {
             return &mOptions;

--- a/src/webnn_native/ops/Binary.h
+++ b/src/webnn_native/ops/Binary.h
@@ -35,23 +35,23 @@ namespace webnn_native { namespace op {
       public:
         Binary(GraphBuilderBase* builder, BinaryOpType opType, OperandBase* a, OperandBase* b)
             : OperatorBase(builder, {a, b}), mOpType(opType) {
-            // For element-wise binary ops, The rank of the output tensor
+            // For element-wise binary ops, The Shape().size() of the output tensor
             // is the maximum rank of the input tensors.
             // According to
             // [numpy-broadcasting-rule](https://webmachinelearning.github.io/webnn/#biblio-numpy-broadcasting-rule)
             // For matmul
-            // 1. if a->Rank() == 2 && b->Rank() == 2, rank_ = 2;
-            // 2. if a->Rank() > 2 || b->Rank() > 2, rank_ = std::max(a->Rank(), b->Rank());
-            // 3. if a->Rank() == 1 && b->Rank() == 1, rank_ = 0;
-            // 4. if a->Rank() == 1 && b->Rank() == 2, rank_ = 2;
-            // 5. if a->Rank() == 2 && b->Rank() == 1, rank_ = 2;
+            // 1. if a->Shape().size() == 2 && b->Shape().size() == 2, rank_ = 2;
+            // 2. if a->Shape().size() > 2 || b->Shape().size() > 2, rank_ =
+            // std::max(a->Shape().size(), b->Shape().size());
+            // 3. if a->Shape().size() == 1 && b->Shape().size() == 1, rank_ = 0;
+            // 4. if a->Shape().size() == 1 && b->Shape().size() == 2, rank_ = 2;
+            // 5. if a->Shape().size() == 2 && b->Shape().size() == 1, rank_ = 2;
             uint32_t rank = 0;
-            if (mOpType == kMatMul && a->Rank() == 1 && b->Rank() == 1) {
+            if (mOpType == kMatMul && a->Shape().size() == 1 && b->Shape().size() == 1) {
                 rank = 0;
             } else {
-                rank = std::max(a->Rank(), b->Rank());
+                rank = std::max(a->Shape().size(), b->Shape().size());
             }
-            mOutputs[0]->SetRank(rank);
         }
         ~Binary() override = default;
 
@@ -61,6 +61,7 @@ namespace webnn_native { namespace op {
         BinaryOpType GetType() const {
             return mOpType;
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
       private:

--- a/src/webnn_native/ops/Binary.h
+++ b/src/webnn_native/ops/Binary.h
@@ -35,23 +35,6 @@ namespace webnn_native { namespace op {
       public:
         Binary(GraphBuilderBase* builder, BinaryOpType opType, OperandBase* a, OperandBase* b)
             : OperatorBase(builder, {a, b}), mOpType(opType) {
-            // For element-wise binary ops, The Shape().size() of the output tensor
-            // is the maximum rank of the input tensors.
-            // According to
-            // [numpy-broadcasting-rule](https://webmachinelearning.github.io/webnn/#biblio-numpy-broadcasting-rule)
-            // For matmul
-            // 1. if a->Shape().size() == 2 && b->Shape().size() == 2, rank_ = 2;
-            // 2. if a->Shape().size() > 2 || b->Shape().size() > 2, rank_ =
-            // std::max(a->Shape().size(), b->Shape().size());
-            // 3. if a->Shape().size() == 1 && b->Shape().size() == 1, rank_ = 0;
-            // 4. if a->Shape().size() == 1 && b->Shape().size() == 2, rank_ = 2;
-            // 5. if a->Shape().size() == 2 && b->Shape().size() == 1, rank_ = 2;
-            uint32_t rank = 0;
-            if (mOpType == kMatMul && a->Shape().size() == 1 && b->Shape().size() == 1) {
-                rank = 0;
-            } else {
-                rank = std::max(a->Shape().size(), b->Shape().size());
-            }
         }
         ~Binary() override = default;
 
@@ -61,10 +44,11 @@ namespace webnn_native { namespace op {
         BinaryOpType GetType() const {
             return mOpType;
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+
+        MaybeError ValidateAndInferOutputInfo() override;
 
       private:
+        MaybeError CalculateShape();
         BinaryOpType mOpType;
     };
 

--- a/src/webnn_native/ops/Binary.h
+++ b/src/webnn_native/ops/Binary.h
@@ -48,7 +48,8 @@ namespace webnn_native { namespace op {
         MaybeError ValidateAndInferOutputInfo() override;
 
       private:
-        MaybeError CalculateShape();
+        MaybeError CaculateMatMulShape();
+        MaybeError CaculateElementWiseBinaryShape();
         BinaryOpType mOpType;
     };
 

--- a/src/webnn_native/ops/Clamp.h
+++ b/src/webnn_native/ops/Clamp.h
@@ -46,6 +46,7 @@ namespace webnn_native { namespace op {
       public:
         Clamp(GraphBuilderBase* builder, OperandBase* input, ClampOptions const* options)
             : ClampBase(options), OperatorBase(builder, {input}) {
+            mOutputs[0]->SetShape(input->Shape());
         }
         Clamp(GraphBuilderBase* builder, ClampOptions const* options)
             : ClampBase(options), OperatorBase(builder, FusedOperator::Clamp) {

--- a/src/webnn_native/ops/Clamp.h
+++ b/src/webnn_native/ops/Clamp.h
@@ -46,7 +46,6 @@ namespace webnn_native { namespace op {
       public:
         Clamp(GraphBuilderBase* builder, OperandBase* input, ClampOptions const* options)
             : ClampBase(options), OperatorBase(builder, {input}) {
-            mOutputs[0]->SetShape(input->Shape());
         }
         Clamp(GraphBuilderBase* builder, ClampOptions const* options)
             : ClampBase(options), OperatorBase(builder, FusedOperator::Clamp) {
@@ -55,6 +54,18 @@ namespace webnn_native { namespace op {
 
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddClamp(this);
+        }
+
+        MaybeError ValidateAndInferOutputInfo() override {
+            MaybeError maybeError = OperatorBase::ValidateAndInferOutputInfo();
+            if (maybeError.IsError()) {
+                return maybeError;
+            }
+            if (!mInputs.empty()) {
+                mOutputs[0]->SetShape(mInputs[0]->Shape());
+            }
+
+            return {};
         }
     };
 

--- a/src/webnn_native/ops/Concat.cpp
+++ b/src/webnn_native/ops/Concat.cpp
@@ -17,6 +17,30 @@
 #include "webnn_native/Error.h"
 
 namespace webnn_native { namespace op {
+    MaybeError Concat::CalculateShape() {
+        auto inputShape =
+            mInputs[0]->Shape().empty() ? std::vector<int32_t>{1} : mInputs[0]->Shape();
+        int32_t axisShape = 0;
+        for (auto& input : mInputs) {
+            auto shape = input->Shape();
+            if (shape.size() != inputShape.size()) {
+                return DAWN_VALIDATION_ERROR("The input shapes are incompatible.");
+            }
+            axisShape += shape[mAxis];
+
+            for (size_t i = 0; i < inputShape.size(); ++i) {
+                if (uint32_t(i) != mAxis && shape[i] != inputShape[i]) {
+                    return DAWN_VALIDATION_ERROR(
+                        "All input tensors must have the same shape, except for the size of the "
+                        "dimension to concatenate on.");
+                }
+            }
+        }
+        auto outputShape = inputShape;
+        outputShape[mAxis] = axisShape;
+        mOutputs[0]->SetShape(outputShape);
+        return {};
+    }
 
     MaybeError Concat::Validate() {
         MaybeError maybeError = OperatorBase::Validate();
@@ -25,20 +49,18 @@ namespace webnn_native { namespace op {
         }
 
         auto inputType = mInputs[0]->Type();
-        auto inputRank = mInputs[0]->Rank();
         for (auto& input : mInputs) {
             if (input->Type() != inputType) {
                 return DAWN_VALIDATION_ERROR("Argument types are inconsistent.");
             }
-            if (input->Rank() != inputRank) {
-                return DAWN_VALIDATION_ERROR(
-                    "Argument inputs must have same shape except for the size of the dimension to "
-                    "concatenate on.");
-            }
         }
-
+        auto inputRank = mInputs[0]->Shape().empty() ? 1 : mInputs[0]->Shape().size();
         if (mAxis >= inputRank) {
             return DAWN_VALIDATION_ERROR("The axis is out of rank range.");
+        }
+        maybeError = CalculateShape();
+        if (maybeError.IsError()) {
+            return maybeError;
         }
         return {};
     }

--- a/src/webnn_native/ops/Concat.h
+++ b/src/webnn_native/ops/Concat.h
@@ -35,10 +35,10 @@ namespace webnn_native { namespace op {
         uint32_t GetAxis() const {
             return mAxis;
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
       private:
+        MaybeError CalculateShape();
         uint32_t mAxis;
     };
 

--- a/src/webnn_native/ops/Concat.h
+++ b/src/webnn_native/ops/Concat.h
@@ -35,6 +35,7 @@ namespace webnn_native { namespace op {
         uint32_t GetAxis() const {
             return mAxis;
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
       private:

--- a/src/webnn_native/ops/Constant.h
+++ b/src/webnn_native/ops/Constant.h
@@ -35,9 +35,6 @@ namespace webnn_native { namespace op {
             mDescriptor.type = desc->type;
             mBuffer = static_cast<int8_t*>(arrayBuffer->buffer) + arrayBuffer->byteOffset;
             mByteLength = arrayBuffer->byteLength;
-
-            mOutputs[0]->SetType(desc->type);
-            mOutputs[0]->SetShape(mDimensions);
         }
         ~Constant() override = default;
 
@@ -45,10 +42,12 @@ namespace webnn_native { namespace op {
             return graph->AddConstant(this);
         }
 
-        MaybeError Validate() override {
+        MaybeError ValidateAndInferOutputInfo() override {
             if (mBuffer == nullptr || mByteLength == 0) {
                 return DAWN_VALIDATION_ERROR("Constant array buffer is invalid.");
             }
+            mOutputs[0]->SetType(mDescriptor.type);
+            mOutputs[0]->SetShape(mDimensions);
             return {};
         }
 

--- a/src/webnn_native/ops/Constant.h
+++ b/src/webnn_native/ops/Constant.h
@@ -36,8 +36,8 @@ namespace webnn_native { namespace op {
             mBuffer = static_cast<int8_t*>(arrayBuffer->buffer) + arrayBuffer->byteOffset;
             mByteLength = arrayBuffer->byteLength;
 
-            mOutputs[0]->SetRank(desc->dimensionsCount);
             mOutputs[0]->SetType(desc->type);
+            mOutputs[0]->SetShape(mDimensions);
         }
         ~Constant() override = default;
 
@@ -55,9 +55,11 @@ namespace webnn_native { namespace op {
         const OperandDescriptor* GetOperandDescriptor() const {
             return &mDescriptor;
         }
+
         void const* GetBuffer() const {
             return mBuffer;
         }
+
         size_t GetByteLength() const {
             return mByteLength;
         }

--- a/src/webnn_native/ops/Conv2d.cpp
+++ b/src/webnn_native/ops/Conv2d.cpp
@@ -15,8 +15,8 @@
 #include "webnn_native/ops/Conv2d.h"
 
 #include "webnn_native/Error.h"
-#include "webnn_native/NativeUtils.h"
 #include "webnn_native/Operator.h"
+#include "webnn_native/Utils.h"
 
 namespace webnn_native { namespace op {
 
@@ -135,12 +135,12 @@ namespace webnn_native { namespace op {
         int32_t paddingBeginningHeight = mPadding[0], paddingEndingHeight = mPadding[1],
                 paddingBeginningWidth = mPadding[2], paddingEndingWidth = mPadding[3];
         if (mOptions.autoPad != ml::AutoPad::Explicit) {
-            ComputeImplicitPaddingForAutoPad(mOptions.autoPad, mOptions.dilations[0], inputHeight,
-                                             filterHeight, mOptions.strides[0],
-                                             paddingBeginningHeight, paddingEndingHeight);
-            ComputeImplicitPaddingForAutoPad(mOptions.autoPad, mOptions.dilations[1], inputWidth,
-                                             filterWidth, mOptions.strides[1],
-                                             paddingBeginningWidth, paddingEndingWidth);
+            utils::ComputeImplicitPaddingForAutoPad(mOptions.autoPad, mOptions.dilations[0],
+                                                    inputHeight, filterHeight, mOptions.strides[0],
+                                                    paddingBeginningHeight, paddingEndingHeight);
+            utils::ComputeImplicitPaddingForAutoPad(mOptions.autoPad, mOptions.dilations[1],
+                                                    inputWidth, filterWidth, mOptions.strides[1],
+                                                    paddingBeginningWidth, paddingEndingWidth);
         }
 
         int32_t outputHeight, outputWidth;

--- a/src/webnn_native/ops/Conv2d.h
+++ b/src/webnn_native/ops/Conv2d.h
@@ -29,8 +29,9 @@ namespace webnn_native { namespace op {
         ~Conv2d() override = default;
 
         MaybeError AddToGraph(GraphBase* graph) const override;
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
-
+        void ReorderFilterShapeToOihw(ml::FilterOperandLayout layout, std::vector<int32_t>& shape);
         Conv2dOptions const* GetOptions() const;
 
       private:

--- a/src/webnn_native/ops/Conv2d.h
+++ b/src/webnn_native/ops/Conv2d.h
@@ -29,12 +29,11 @@ namespace webnn_native { namespace op {
         ~Conv2d() override = default;
 
         MaybeError AddToGraph(GraphBase* graph) const override;
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
-        void ReorderFilterShapeToOihw(ml::FilterOperandLayout layout, std::vector<int32_t>& shape);
+        MaybeError ValidateAndInferOutputInfo() override;
         Conv2dOptions const* GetOptions() const;
 
       private:
+        MaybeError CalculateShape();
         Conv2dOptions mOptions;
         std::vector<int32_t> mPadding;
         std::vector<int32_t> mStride;

--- a/src/webnn_native/ops/Gemm.cpp
+++ b/src/webnn_native/ops/Gemm.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 
-#include "common/Log.h"
 #include "webnn_native/Error.h"
 
 namespace webnn_native { namespace op {
@@ -29,23 +28,50 @@ namespace webnn_native { namespace op {
         mOptions.beta = options == nullptr ? 1.0 : options->beta;
         mOptions.aTranspose = options == nullptr ? false : options->aTranspose;
         mOptions.bTranspose = options == nullptr ? false : options->bTranspose;
-        if (options->c) {
+        if (options != nullptr && options->c) {
             mInputs.push_back(options->c);
         }
     }
 
     MaybeError Gemm::CalculateShape() {
+        // The first input 2-D tensor with shape [M, K] if aTranspose is false, or [K, M] if
+        // aTranspose is true. The second input 2-D tensor with shape [K, N] if bTranspose is false,
+        // or [N, K] if bTranspose is true.
         auto inputAShape = mInputs[0]->Shape();
         auto inputBShape = mInputs[1]->Shape();
-        std::vector<int32_t> outputShape(2);
-        outputShape[0] = mOptions.aTranspose ? inputAShape[1] : inputAShape[0];
-        outputShape[1] = mOptions.bTranspose ? inputBShape[0] : inputBShape[1];
-        mOutputs[0]->SetShape(outputShape);
+        bool matMulSupported = (mOptions.aTranspose ? inputAShape[0] : inputAShape[1]) ==
+                               (mOptions.bTranspose ? inputBShape[1] : inputBShape[0]);
+        if (!matMulSupported) {
+            return DAWN_VALIDATION_ERROR(
+                "Matrix multiplication failed, K should be same in the two input tensors.");
+        }
+        std::vector<int32_t> outputShape = {mOptions.aTranspose ? inputAShape[1] : inputAShape[0],
+                                            mOptions.bTranspose ? inputBShape[0] : inputBShape[1]};
+        // The third input tensor c is either a scalar, or of the shape that is unidirectionally
+        // broadcastable to the shape [M, N].
+        if (mInputs.size() == 3) {
+            auto cShape = mInputs[2]->Shape();
+            if (cShape.size() > 2) {
+                return DAWN_VALIDATION_ERROR(
+                    "The specified third input is either a scalar, or of the shape that is "
+                    "unidirectionally broadcastable.");
+            }
+
+            for (int32_t i = cShape.size() - 1, j = outputShape.size() - 1; i >= 0 && j >= 0;
+                 --i, --j) {
+                if (cShape[i] != outputShape[j] && cShape[i] != 1) {
+                    return DAWN_VALIDATION_ERROR(
+                        "The specified third input is either a scalar, or of the shape that is "
+                        "unidirectionally broadcastable.");
+                }
+            }
+        }
+        mOutputs[0]->SetShape(std::move(outputShape));
         return {};
     }
 
-    MaybeError Gemm::Validate() {
-        MaybeError maybeError = OperatorBase::Validate();
+    MaybeError Gemm::ValidateAndInferOutputInfo() {
+        MaybeError maybeError = OperatorBase::ValidateAndInferOutputInfo();
         if (maybeError.IsError()) {
             return maybeError;
         }
@@ -55,18 +81,8 @@ namespace webnn_native { namespace op {
         if (mInputs[1]->Shape().size() != 2) {
             return DAWN_VALIDATION_ERROR("The second input is not 2D.");
         }
-        if (mInputs.size() == 3) {
-            if (mInputs[2]->Shape().size() > 2) {
-                return DAWN_VALIDATION_ERROR(
-                    "The specified third input is either a scalar, or of the shape that is "
-                    "unidirectionally broadcastable.");
-            }
-        }
-        maybeError = CalculateShape();
-        if (maybeError.IsError()) {
-            return maybeError;
-        }
-        return {};
+
+        return CalculateShape();
     }
 
 }}  // namespace webnn_native::op

--- a/src/webnn_native/ops/Gemm.h
+++ b/src/webnn_native/ops/Gemm.h
@@ -28,6 +28,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddGemm(this);
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
         GemmOptions const* GetOptions() const {

--- a/src/webnn_native/ops/Gemm.h
+++ b/src/webnn_native/ops/Gemm.h
@@ -28,14 +28,14 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddGemm(this);
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
         GemmOptions const* GetOptions() const {
             return &mOptions;
         }
 
       private:
+        MaybeError CalculateShape();
         GemmOptions mOptions;
     };
 

--- a/src/webnn_native/ops/Gru.h
+++ b/src/webnn_native/ops/Gru.h
@@ -36,8 +36,8 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddGru(this);
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+
+        MaybeError ValidateAndInferOutputInfo() override;
 
         GruOptions const* GetOptions() const {
             return &mOptions;
@@ -56,6 +56,7 @@ namespace webnn_native { namespace op {
         }
 
       private:
+        MaybeError CalculateShape();
         GruOptions mOptions;
         size_t mSteps;
         size_t mHiddenSize;

--- a/src/webnn_native/ops/Gru.h
+++ b/src/webnn_native/ops/Gru.h
@@ -36,6 +36,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddGru(this);
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
         GruOptions const* GetOptions() const {

--- a/src/webnn_native/ops/Input.h
+++ b/src/webnn_native/ops/Input.h
@@ -29,17 +29,21 @@ namespace webnn_native { namespace op {
             : OperatorBase(builder), mName(name) {
             mDescriptor.type = desc->type;
             mDimensions.assign(desc->dimensions, desc->dimensions + desc->dimensionsCount);
+            if (mDimensions.data() == nullptr) {
+                mDimensions = {1};
+            }
             mDescriptor.dimensions = mDimensions.data();
             mDescriptor.dimensionsCount = mDimensions.size();
 
-            mOutputs[0]->SetRank(desc->dimensionsCount);
             mOutputs[0]->SetType(desc->type);
+            mOutputs[0]->SetShape(mDimensions);
         }
         ~Input() override = default;
 
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddInput(this);
         }
+
         MaybeError Validate() override {
             return {};
         }
@@ -47,6 +51,7 @@ namespace webnn_native { namespace op {
         const std::string& GetName() const {
             return mName;
         }
+
         const OperandDescriptor* GetOperandDescriptor() const {
             return &mDescriptor;
         }

--- a/src/webnn_native/ops/Input.h
+++ b/src/webnn_native/ops/Input.h
@@ -29,14 +29,8 @@ namespace webnn_native { namespace op {
             : OperatorBase(builder), mName(name) {
             mDescriptor.type = desc->type;
             mDimensions.assign(desc->dimensions, desc->dimensions + desc->dimensionsCount);
-            if (mDimensions.data() == nullptr) {
-                mDimensions = {1};
-            }
             mDescriptor.dimensions = mDimensions.data();
             mDescriptor.dimensionsCount = mDimensions.size();
-
-            mOutputs[0]->SetType(desc->type);
-            mOutputs[0]->SetShape(mDimensions);
         }
         ~Input() override = default;
 
@@ -44,7 +38,9 @@ namespace webnn_native { namespace op {
             return graph->AddInput(this);
         }
 
-        MaybeError Validate() override {
+        MaybeError ValidateAndInferOutputInfo() override {
+            mOutputs[0]->SetType(mDescriptor.type);
+            mOutputs[0]->SetShape(mDimensions);
             return {};
         }
 

--- a/src/webnn_native/ops/InstanceNorm.cpp
+++ b/src/webnn_native/ops/InstanceNorm.cpp
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 
-#include "common/Log.h"
 #include "webnn_native/Error.h"
 
 namespace webnn_native { namespace op {
@@ -38,8 +37,8 @@ namespace webnn_native { namespace op {
         }
     }
 
-    MaybeError InstanceNorm::Validate() {
-        MaybeError maybeError = OperatorBase::Validate();
+    MaybeError InstanceNorm::ValidateAndInferOutputInfo() {
+        MaybeError maybeError = OperatorBase::ValidateAndInferOutputInfo();
         if (maybeError.IsError()) {
             return maybeError;
         }
@@ -64,10 +63,9 @@ namespace webnn_native { namespace op {
                 return DAWN_VALIDATION_ERROR("Argument bias is not a 1D tensor.");
             }
         }
-        maybeError = CalculateShape();
-        if (maybeError.IsError()) {
-            return maybeError;
-        }
+
+        mOutputs[0]->SetShape(mInputs[0]->Shape());
+
         return {};
     }
 

--- a/src/webnn_native/ops/InstanceNorm.cpp
+++ b/src/webnn_native/ops/InstanceNorm.cpp
@@ -45,14 +45,14 @@ namespace webnn_native { namespace op {
         }
 
         // The input is 4-D tensor.
-        if (mInputs[0]->Rank() != 4) {
+        if (mInputs[0]->Shape().size() != 4) {
             return DAWN_VALIDATION_ERROR("Input is not a 4D tensor.");
         }
 
         // The scale is 1-D tensor.
         if (mOptions.scale != nullptr) {
             auto scale = mInputs[1];
-            if (scale->Rank() != 1) {
+            if (scale->Shape().size() != 1) {
                 return DAWN_VALIDATION_ERROR("Argument scale is not a 1D tensor.");
             }
         }
@@ -60,11 +60,14 @@ namespace webnn_native { namespace op {
         if (mOptions.bias != nullptr) {
             size_t biasIndex = mOptions.scale != nullptr ? 2 : 1;
             auto bias = mInputs[biasIndex];
-            if (bias->Rank() != 1) {
+            if (bias->Shape().size() != 1) {
                 return DAWN_VALIDATION_ERROR("Argument bias is not a 1D tensor.");
             }
         }
-
+        maybeError = CalculateShape();
+        if (maybeError.IsError()) {
+            return maybeError;
+        }
         return {};
     }
 

--- a/src/webnn_native/ops/InstanceNorm.h
+++ b/src/webnn_native/ops/InstanceNorm.h
@@ -30,7 +30,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddInstanceNorm(this);
         }
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
         InstanceNormOptions const* GetOptions() const {
             return &mOptions;

--- a/src/webnn_native/ops/Pad.cpp
+++ b/src/webnn_native/ops/Pad.cpp
@@ -30,32 +30,37 @@ namespace webnn_native { namespace op {
     MaybeError Pad::CalculateShape() {
         auto inputShape = mInputs[0]->Shape();
         auto paddingShape = mInputs[1]->Shape();
+        std::vector<int32_t> outputShape(inputShape.size());
+        // TODO(mingming): Need to check whether padding is a constant.
+        const op::Constant* padding = reinterpret_cast<const op::Constant*>(mInputs[1]->Operator());
+        const uint32_t* padBuffer = static_cast<const uint32_t*>(padding->GetBuffer());
+        // For each dimension D of input, padding[D, 0] indicates how many values to add before the
+        // content in that dimension, and padding[D, 1] indicates how many values to add after the
+        // content in that dimension.
+        for (size_t i = 0; i < inputShape.size(); ++i) {
+            outputShape[i] = inputShape[i] + padBuffer[2 * i] + padBuffer[2 * i + 1];
+        }
+        mOutputs[0]->SetShape(std::move(outputShape));
+        return {};
+    }
+
+    MaybeError Pad::ValidateAndInferOutputInfo() {
+        MaybeError maybeError = OperatorBase::ValidateAndInferOutputInfo();
+        if (maybeError.IsError()) {
+            return maybeError;
+        }
+
+        auto inputShape = mInputs[0]->Shape();
+        auto paddingShape = mInputs[1]->Shape();
+
         if (paddingShape.size() != 2 || inputShape.size() != size_t(paddingShape[0]) ||
             paddingShape[1] != 2) {
             return DAWN_VALIDATION_ERROR(
                 "The padding tensor should has shape [n, 2] where n is the rank of the input "
                 "tensor.");
         }
-        std::vector<int32_t> outputShape(inputShape.size());
-        const op::Constant* padding = reinterpret_cast<const op::Constant*>(mInputs[1]->Operator());
-        const uint32_t* padBuffer = static_cast<const uint32_t*>(padding->GetBuffer());
-        for (size_t i = 0; i < inputShape.size(); ++i) {
-            outputShape[i] = inputShape[i] + padBuffer[2 * i] + padBuffer[2 * i + 1];
-        }
-        mOutputs[0]->SetShape(outputShape);
-        return {};
-    }
 
-    MaybeError Pad::Validate() {
-        MaybeError maybeError = OperatorBase::Validate();
-        if (maybeError.IsError()) {
-            return maybeError;
-        }
-        maybeError = CalculateShape();
-        if (maybeError.IsError()) {
-            return maybeError;
-        }
-        return {};
+        return CalculateShape();
     }
 
 }}  // namespace webnn_native::op

--- a/src/webnn_native/ops/Pad.cpp
+++ b/src/webnn_native/ops/Pad.cpp
@@ -27,15 +27,34 @@ namespace webnn_native { namespace op {
         mOptions.value = options == nullptr ? 0 : options->value;
     }
 
+    MaybeError Pad::CalculateShape() {
+        auto inputShape = mInputs[0]->Shape();
+        auto paddingShape = mInputs[1]->Shape();
+        if (paddingShape.size() != 2 || inputShape.size() != size_t(paddingShape[0]) ||
+            paddingShape[1] != 2) {
+            return DAWN_VALIDATION_ERROR(
+                "The padding tensor should has shape [n, 2] where n is the rank of the input "
+                "tensor.");
+        }
+        std::vector<int32_t> outputShape(inputShape.size());
+        const op::Constant* padding = reinterpret_cast<const op::Constant*>(mInputs[1]->Operator());
+        const uint32_t* padBuffer = static_cast<const uint32_t*>(padding->GetBuffer());
+        for (size_t i = 0; i < inputShape.size(); ++i) {
+            outputShape[i] = inputShape[i] + padBuffer[2 * i] + padBuffer[2 * i + 1];
+        }
+        mOutputs[0]->SetShape(outputShape);
+        return {};
+    }
+
     MaybeError Pad::Validate() {
         MaybeError maybeError = OperatorBase::Validate();
         if (maybeError.IsError()) {
             return maybeError;
         }
-        if (mInputs[1]->Rank() != 2) {
-            return DAWN_VALIDATION_ERROR("The padding is not 2D.");
+        maybeError = CalculateShape();
+        if (maybeError.IsError()) {
+            return maybeError;
         }
-
         return {};
     }
 

--- a/src/webnn_native/ops/Pad.h
+++ b/src/webnn_native/ops/Pad.h
@@ -32,6 +32,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddPad(this);
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
         PadOptions const* GetOptions() const {

--- a/src/webnn_native/ops/Pad.h
+++ b/src/webnn_native/ops/Pad.h
@@ -32,14 +32,14 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddPad(this);
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
         PadOptions const* GetOptions() const {
             return &mOptions;
         }
 
       private:
+        MaybeError CalculateShape();
         PadOptions mOptions;
     };
 

--- a/src/webnn_native/ops/Pool2d.cpp
+++ b/src/webnn_native/ops/Pool2d.cpp
@@ -15,7 +15,7 @@
 #include "webnn_native/ops/Pool2d.h"
 
 #include "webnn_native/Error.h"
-#include "webnn_native/NativeUtils.h"
+#include "webnn_native/Utils.h"
 
 namespace webnn_native { namespace op {
 
@@ -89,12 +89,12 @@ namespace webnn_native { namespace op {
         int32_t paddingBeginningHeight = mPadding[0], paddingEndingHeight = mPadding[1],
                 paddingBeginningWidth = mPadding[2], paddingEndingWidth = mPadding[3];
         if (mOptions.autoPad != ml::AutoPad::Explicit) {
-            ComputeImplicitPaddingForAutoPad(mOptions.autoPad, mOptions.dilations[0], inputHeight,
-                                             windowHeight, mOptions.strides[0],
-                                             paddingBeginningHeight, paddingEndingHeight);
-            ComputeImplicitPaddingForAutoPad(mOptions.autoPad, mOptions.dilations[1], inputWidth,
-                                             windowWidth, mOptions.strides[1],
-                                             paddingBeginningWidth, paddingEndingWidth);
+            utils::ComputeImplicitPaddingForAutoPad(mOptions.autoPad, mOptions.dilations[0],
+                                                    inputHeight, windowHeight, mOptions.strides[0],
+                                                    paddingBeginningHeight, paddingEndingHeight);
+            utils::ComputeImplicitPaddingForAutoPad(mOptions.autoPad, mOptions.dilations[1],
+                                                    inputWidth, windowWidth, mOptions.strides[1],
+                                                    paddingBeginningWidth, paddingEndingWidth);
         }
         // TODO(mingming): Support ceil and floor rounding types for pool2d.
         int32_t outputHeight =

--- a/src/webnn_native/ops/Pool2d.h
+++ b/src/webnn_native/ops/Pool2d.h
@@ -35,13 +35,13 @@ namespace webnn_native { namespace op {
         ~Pool2d() override = default;
 
         MaybeError AddToGraph(GraphBase* graph) const override;
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
         Pool2dOptions const* GetOptions() const;
         Pool2dType GetType() const;
 
       private:
+        MaybeError CalculateShape();
         Pool2dOptions mOptions;
         std::vector<int32_t> mWindowDimensions;
         std::vector<int32_t> mPadding;

--- a/src/webnn_native/ops/Pool2d.h
+++ b/src/webnn_native/ops/Pool2d.h
@@ -35,6 +35,7 @@ namespace webnn_native { namespace op {
         ~Pool2d() override = default;
 
         MaybeError AddToGraph(GraphBase* graph) const override;
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
         Pool2dOptions const* GetOptions() const;

--- a/src/webnn_native/ops/Reduce.h
+++ b/src/webnn_native/ops/Reduce.h
@@ -44,6 +44,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddReduce(this);
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
         ReduceType GetType() const {

--- a/src/webnn_native/ops/Reduce.h
+++ b/src/webnn_native/ops/Reduce.h
@@ -15,7 +15,6 @@
 #ifndef WEBNN_NATIVE_OPS_REDUCE_H_
 #define WEBNN_NATIVE_OPS_REDUCE_H_
 
-#include "common/Log.h"
 #include "webnn_native/Graph.h"
 #include "webnn_native/Operand.h"
 #include "webnn_native/Operator.h"
@@ -44,8 +43,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddReduce(this);
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
         ReduceType GetType() const {
             return mOpType;
@@ -56,6 +54,7 @@ namespace webnn_native { namespace op {
         }
 
       private:
+        MaybeError CalculateShape();
         ReduceType mOpType;
         ReduceOptions mOptions;
         std::vector<int32_t> mAxes;

--- a/src/webnn_native/ops/Resample.h
+++ b/src/webnn_native/ops/Resample.h
@@ -28,6 +28,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddResample(this);
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
         ResampleOptions const* GetOptions() const {

--- a/src/webnn_native/ops/Resample.h
+++ b/src/webnn_native/ops/Resample.h
@@ -28,14 +28,14 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddResample(this);
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
         ResampleOptions const* GetOptions() const {
             return &mOptions;
         }
 
       private:
+        MaybeError CalculateShape();
         ResampleOptions mOptions;
         std::vector<float> mScales;
         std::vector<int32_t> mSizes;

--- a/src/webnn_native/ops/Reshape.cpp
+++ b/src/webnn_native/ops/Reshape.cpp
@@ -19,25 +19,55 @@
 
 namespace webnn_native { namespace op {
 
+    MaybeError Reshape::CalculateShape() {
+        auto inputShape =
+            mInputs[0]->Shape().empty() ? std::vector<int32_t>{1} : mInputs[0]->Shape();
+        uint32_t inputSize = 1, capacity = 1;
+        for (auto dim : inputShape) {
+            inputSize *= dim;
+        }
+        int unkDimIdx = -1;
+        bool hasMinus1 = false;
+        std::vector<int32_t> outputShape(mNewShape.size());
+        for (size_t i = 0; i < mNewShape.size(); ++i) {
+            int32_t dim = mNewShape[i];
+            if (dim < -1) {
+                return DAWN_VALIDATION_ERROR(
+                    "The component of newShape should not be smaller than -1.");
+            }
+            if (dim == -1) {
+                if (hasMinus1) {
+                    return DAWN_VALIDATION_ERROR(
+                        "Only one component of newShape can be the special value of -1.");
+                }
+                unkDimIdx = i;
+                hasMinus1 = true;
+            } else {
+                capacity *= dim;
+                outputShape[i] = dim;
+            }
+        }
+
+        if (hasMinus1) {
+            outputShape[unkDimIdx] = inputSize / capacity;
+        } else {
+            if (inputSize != capacity) {
+                return DAWN_VALIDATION_ERROR("Total size should keep consistent.");
+            }
+        }
+        mOutputs[0]->SetShape(outputShape);
+        return {};
+    }
+
     MaybeError Reshape::Validate() {
         MaybeError maybeError = OperatorBase::Validate();
         if (maybeError.IsError()) {
             return maybeError;
         }
-
-        bool hasMinus1 = false;
-        // Only one component of newShape can be the special value of -1
-        for (auto i : mNewShape) {
-            if (i < -1 || i == 0) {
-                return DAWN_VALIDATION_ERROR("Argument newShape is invalid.");
-            } else if (i == -1) {
-                if (hasMinus1) {
-                    return DAWN_VALIDATION_ERROR("Argument newShape is invalid.");
-                }
-                hasMinus1 = true;
-            }
+        maybeError = CalculateShape();
+        if (maybeError.IsError()) {
+            return maybeError;
         }
-
         return {};
     }
 

--- a/src/webnn_native/ops/Reshape.h
+++ b/src/webnn_native/ops/Reshape.h
@@ -35,13 +35,13 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddReshape(this);
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
         std::vector<int32_t> GetNewShape() const {
             return mNewShape;
         }
 
       private:
+        MaybeError CalculateShape();
         std::vector<int32_t> mNewShape;
     };
 

--- a/src/webnn_native/ops/Reshape.h
+++ b/src/webnn_native/ops/Reshape.h
@@ -29,14 +29,13 @@ namespace webnn_native { namespace op {
                 size_t newShapeCount)
             : OperatorBase(builder, {input}) {
             mNewShape.assign(newShape, newShape + newShapeCount);
-
-            mOutputs[0]->SetRank(mNewShape.size());
         }
         ~Reshape() override = default;
 
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddReshape(this);
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
         std::vector<int32_t> GetNewShape() const {
             return mNewShape;

--- a/src/webnn_native/ops/Squeeze.h
+++ b/src/webnn_native/ops/Squeeze.h
@@ -15,6 +15,8 @@
 #ifndef WEBNN_NATIVE_OPS_SQUEEZE_H_
 #define WEBNN_NATIVE_OPS_SQUEEZE_H_
 
+#include <unordered_set>
+
 #include "webnn_native/Graph.h"
 #include "webnn_native/Operand.h"
 #include "webnn_native/Operator.h"
@@ -33,6 +35,57 @@ namespace webnn_native { namespace op {
 
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddSqueeze(this);
+        }
+
+        MaybeError CalculateShape() override {
+            auto inputShape =
+                mInputs[0]->Shape().empty() ? std::vector<int32_t>{1} : mInputs[0]->Shape();
+            auto inputRank = inputShape.size();
+
+            std::unordered_set<int32_t> axesSqueezed;
+            if (mAxes.empty()) {
+                for (size_t i = 0; i < inputRank; ++i) {
+                    if (inputShape[i] == 1) {
+                        axesSqueezed.insert(i);
+                    }
+                }
+            } else {
+                for (const auto& axis : mAxes) {
+                    axesSqueezed.insert(axis);
+                }
+            }
+
+            std::vector<int32_t> outputShape;
+            for (size_t i = 0; i < inputRank; ++i) {
+                if (axesSqueezed.find(i) == axesSqueezed.end()) {
+                    outputShape.push_back(inputShape[i]);
+                }
+            }
+            if (outputShape.empty()) {
+                outputShape = {1};
+            }
+            mOutputs[0]->SetShape(outputShape);
+            return {};
+        }
+
+        MaybeError Validate() override {
+            MaybeError maybeError = OperatorBase::Validate();
+            if (maybeError.IsError()) {
+                return maybeError;
+            }
+
+            auto inputRank = mInputs[0]->Shape().empty() ? 1 : mInputs[0]->Shape().size();
+            for (const auto& axis : mAxes) {
+                if (axis > int32_t(inputRank - 1) || axis < 0) {
+                    return DAWN_VALIDATION_ERROR("Axes value is invalid.");
+                }
+            }
+
+            maybeError = CalculateShape();
+            if (maybeError.IsError()) {
+                return maybeError;
+            }
+            return {};
         }
 
         std::vector<int32_t> GetAxes() const {

--- a/src/webnn_native/ops/Transpose.cpp
+++ b/src/webnn_native/ops/Transpose.cpp
@@ -16,32 +16,31 @@
 
 #include <algorithm>
 
-#include "common/Log.h"
 #include "webnn_native/Error.h"
 
 namespace webnn_native { namespace op {
 
     MaybeError Transpose::CalculateShape() {
-        auto inputShape =
-            mInputs[0]->Shape().empty() ? std::vector<int32_t>{1} : mInputs[0]->Shape();
+        auto inputShape = mInputs[0]->Shape();
         size_t rank = inputShape.size();
         std::vector<int32_t> outputShape(rank);
-        for (size_t i = 0; i < rank; i++) {
+        for (size_t i = 0; i < rank; ++i) {
             outputShape[i] = inputShape[mPermutation[i]];
         }
-        mOutputs[0]->SetShape(outputShape);
+        mOutputs[0]->SetShape(std::move(outputShape));
         return {};
     }
 
-    MaybeError Transpose::Validate() {
-        MaybeError maybeError = OperatorBase::Validate();
+    MaybeError Transpose::ValidateAndInferOutputInfo() {
+        MaybeError maybeError = OperatorBase::ValidateAndInferOutputInfo();
         if (maybeError.IsError()) {
             return maybeError;
         }
 
-        // the number of values in the sequence must be the same as the rank of the input tensor
-        auto inputRank = mInputs[0]->Shape().empty() ? 1 : mInputs[0]->Shape().size();
-        if (mPermutation.size() != size_t(inputRank)) {
+        auto inputShape = mInputs[0]->Shape();
+        // the number of values in the sequence must be the same as the rank of the input
+        // tensor
+        if (mPermutation.size() != inputShape.size()) {
             return DAWN_VALIDATION_ERROR("permutation size is invalid.");
         }
 
@@ -50,16 +49,13 @@ namespace webnn_native { namespace op {
         std::vector<uint32_t> newPermutation;
         newPermutation.assign(mPermutation.begin(), mPermutation.end());
         std::sort(newPermutation.begin(), newPermutation.end());
-        for (uint32_t i = 0; i < inputRank - 1; i++) {
+        for (uint32_t i = 0; i < inputShape.size(); ++i) {
             if (newPermutation[i] != i) {
                 return DAWN_VALIDATION_ERROR("permutation value is invalid.");
             }
         }
-        maybeError = CalculateShape();
-        if (maybeError.IsError()) {
-            return maybeError;
-        }
-        return {};
+
+        return CalculateShape();
     }
 
 }}  // namespace webnn_native::op

--- a/src/webnn_native/ops/Transpose.h
+++ b/src/webnn_native/ops/Transpose.h
@@ -26,7 +26,7 @@ namespace webnn_native { namespace op {
         Transpose(GraphBuilderBase* builder, OperandBase* input, TransposeOptions const* options)
             : OperatorBase(builder, {input}) {
             if (options == nullptr || options->permutation == nullptr) {
-                int32_t rank = input->Rank();
+                int32_t rank = input->Shape().size();
                 mPermutation.resize(rank);
                 for (auto i = 0; i < rank - 1; i++) {
                     mPermutation[i] = rank - 1 - i;
@@ -41,6 +41,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddTranspose(this);
         }
+        MaybeError CalculateShape() override;
         MaybeError Validate() override;
 
         std::vector<int32_t> GetPermutation() const {

--- a/src/webnn_native/ops/Transpose.h
+++ b/src/webnn_native/ops/Transpose.h
@@ -41,14 +41,14 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddTranspose(this);
         }
-        MaybeError CalculateShape() override;
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
 
         std::vector<int32_t> GetPermutation() const {
             return mPermutation;
         }
 
       private:
+        MaybeError CalculateShape();
         std::vector<int32_t> mPermutation;
     };
 

--- a/src/webnn_native/ops/Unary.cpp
+++ b/src/webnn_native/ops/Unary.cpp
@@ -27,11 +27,14 @@ namespace webnn_native { namespace op {
 
         if (mOpType == UnaryOpType::kSoftmax) {
             auto input = mInputs[0];
-            if (input->Rank() != 2) {
+            if (input->Shape().size() != 2) {
                 return DAWN_VALIDATION_ERROR("Input dimensions is incorrect.");
             }
         }
-
+        maybeError = CalculateShape();
+        if (maybeError.IsError()) {
+            return maybeError;
+        }
         return {};
     }
 

--- a/src/webnn_native/ops/Unary.cpp
+++ b/src/webnn_native/ops/Unary.cpp
@@ -14,27 +14,26 @@
 
 #include "webnn_native/ops/Unary.h"
 
-#include "common/Log.h"
 #include "webnn_native/Error.h"
 
 namespace webnn_native { namespace op {
 
-    MaybeError Unary::Validate() {
-        MaybeError maybeError = OperatorBase::Validate();
+    MaybeError Unary::ValidateAndInferOutputInfo() {
+        MaybeError maybeError = OperatorBase::ValidateAndInferOutputInfo();
         if (maybeError.IsError()) {
             return maybeError;
         }
-
         if (mOpType == UnaryOpType::kSoftmax) {
             auto input = mInputs[0];
             if (input->Shape().size() != 2) {
                 return DAWN_VALIDATION_ERROR("Input dimensions is incorrect.");
             }
         }
-        maybeError = CalculateShape();
-        if (maybeError.IsError()) {
-            return maybeError;
+
+        if (!mInputs.empty()) {
+            mOutputs[0]->SetShape(mInputs[0]->Shape());
         }
+
         return {};
     }
 

--- a/src/webnn_native/ops/Unary.h
+++ b/src/webnn_native/ops/Unary.h
@@ -15,7 +15,6 @@
 #ifndef WEBNN_NATIVE_OPS_UNARY_H_
 #define WEBNN_NATIVE_OPS_UNARY_H_
 
-#include "common/Log.h"
 #include "webnn_native/Graph.h"
 #include "webnn_native/Operand.h"
 #include "webnn_native/Operator.h"
@@ -53,7 +52,7 @@ namespace webnn_native { namespace op {
         MaybeError AddToGraph(GraphBase* graph) const override {
             return graph->AddUnary(this);
         }
-        MaybeError Validate() override;
+        MaybeError ValidateAndInferOutputInfo() override;
         UnaryOpType GetType() const {
             return mOpType;
         }


### PR DESCRIPTION
This PR supports calculating output shape of all ops such as: conv, pool, transpose, reshape......

And I also validate them with the shapes produced by native frameworks in both OV and DML backend to make sure they are compatible with each other. 

Now all end2end test cases can pass.