### PR TITLE
Fixed incorrect unpackDir expression

### DIFF
--- a/node/examples/electron/webnn-samples/forge.config.js
+++ b/node/examples/electron/webnn-samples/forge.config.js
@@ -4,7 +4,7 @@ module.exports = {
   packagerConfig: {
     asar: {
       unpack: "node_setup.js",
-      unpackDir: "{lib, build}"
+      unpackDir: "{lib,build}"
    },
   },
   makers: [


### PR DESCRIPTION
Remove whitespace between dirs as which would cause copying fail in app packaging.