### PR TITLE
[MLAS] add the initial implementation of MLAS backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ third_party/gpgmm
 third_party/microsoft.ai.directml*
 third_party/oneDNN
 third_party/XNNPACK
+third_party/onnxruntime
 third_party/stb
 tools
 out

--- a/DEPS
+++ b/DEPS
@@ -49,6 +49,9 @@ deps = {
   'third_party/XNNPACK': {
     'url': '{github_git}/google/XNNPACK.git@60fc61373f21f0ad3164cc719de464f4b787dc04'
   },
+  'third_party/onnxruntime': {
+    'url': '{github_git}/microsoft/onnxruntime.git@0d9030e79888d1d5828730b254fedc53c7b640c1'
+  },
 
   # Dependencies required to use GN/Clang in standalone
   'build': {

--- a/NOTICE
+++ b/NOTICE
@@ -1227,3 +1227,31 @@ https://github.com/intel/GPGMM.git d370f29db790da924ecf341c2a30b0342f497d07
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
+---------------------------------------------------------
+
+---------------------------------------------------------
+
+https://github.com/microsoft/onnxruntime
+
+MIT License
+
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It provides several building blocks:
    - **OpenVINO** on Windows 10 and Linux
    - **oneDNN** on Windows 10 and Linux
    - **XNNPACK** on Windows 10 and Linux
+   - **MLAS** on Windows 10 and Linux
    - _Other backends are to be added_
 
 WebNN-native uses the code of other open source projects:
@@ -31,6 +32,7 @@ WebNN-native uses the code of other open source projects:
  * The DirectMLX and device wrapper of [DirectML](https://github.com/microsoft/DirectML) project.
  * The [XNNPACK](https://github.com/google/XNNPACK) project.
  * The [oneDNN](https://github.com/oneapi-src/oneDNN) project.
+ * The [MLAS](https://github.com/microsoft/onnxruntime/tree/master/onnxruntime/core/mlas) project.
 
 ## Build and Run
 
@@ -72,6 +74,7 @@ To build with a backend, please set the corresponding option from following tabl
 | OpenVINO | `webnn_enable_openvino=true` |
 | XNNPACK | `webnn_enable_xnnpack=true` |
 | oneDNN | `webnn_enable_onednn=true` |
+| MLAS | `webnn_enable_mlas=true` |
 
 ### Build
 
@@ -80,6 +83,7 @@ Then use `ninja -C out/Release` or `ninja -C out/Debug` to build WebNN-native.
 **Notes**
  * To build with XNNPACK backend, please build XNNPACK first, e.g. by [`XNNPACK/scripts/build-local.sh`](https://github.com/google/XNNPACK/blob/master/scripts/build-local.sh).
  * To build with oneDNN backend, please build oneDNN first by following the [build from source instructions](https://oneapi-src.github.io/oneDNN/dev_guide_build.html).
+ * To build with MLAS backend, please build MLAS (part of ONNX Runtime) first by following the [Build ONNX Runtime for inferencing](https://onnxruntime.ai/docs/build/inferencing.html#build-onnx-runtime-for-inferencing), e.g., by `.\build.bat --config Release --parallel --enable_msvc_static_runtime` for Windows build.
 
 ### Run tests
 
@@ -100,7 +104,7 @@ Currently "cpu", "gpu" and "default" are supported, more devices are to be suppo
 
 **Notes**:
  * For OpenVINO backend, please [install 2021.4 version](https://docs.openvinotoolkit.org/2021.4/openvino_docs_install_guides_installing_openvino_linux.html#install-openvino) and [set the environment variables](https://docs.openvinotoolkit.org/2021.4/openvino_docs_install_guides_installing_openvino_linux.html#set-the-environment-variables) before running the end2end tests.
- * The current implementation of XNNPACK and oneDNN backends is mainly for the investigation of WebNN [Operation Level Execution
+ * The current implementation of XNNPACK, oneDNN and MLAS backends is mainly for the investigation of WebNN [Operation Level Execution
 ](https://webmachinelearning.github.io/webnn/#usecase-op-level-exec) use case. So only a limited set of tests (such as of conv2d) is expected to pass.
 
 ### Run examples

--- a/build_overrides/webnn_features.gni
+++ b/build_overrides/webnn_features.gni
@@ -25,6 +25,9 @@ declare_args() {
   # Enables the compilation of XNNPACK backend
   webnn_enable_xnnpack = false
 
+  # Enables the compilation of MLAS backend
+  webnn_enable_mlas = false
+
   # Enables the compilation of WebNN's Null backend
   # (required for unittests, obviously non-conformant)
   webnn_enable_null = true

--- a/src/common/BUILD.gn
+++ b/src/common/BUILD.gn
@@ -83,6 +83,10 @@ config("dawn_internal") {
     defines += [ "WEBNN_ENABLE_BACKEND_XNNPACK" ]
   }
 
+  if (webnn_enable_mlas) {
+    defines += [ "WEBNN_ENABLE_BACKEND_MLAS" ]
+  }
+
   # Only internal Dawn targets can use this config, this means only targets in
   # this BUILD.gn file and related subdirs.
   visibility = [ "../*" ]
@@ -136,7 +140,7 @@ config("dawn_internal") {
     cflags += [ "/wd4063" ]
   }
 
-  if (is_clang && webnn_enable_dml) {
+  if (is_clang && (webnn_enable_dml || webnn_enable_mlas)) {
     cflags += [
       # Allow the use of DEFINE_ENUM_FLAG_OPERATORS(ENUMTYPE); in DirectML.h
       "-Wno-extra-semi",
@@ -146,6 +150,10 @@ config("dawn_internal") {
 
       # Allow the use of DML_OPERATOR_GRAPH_NODE_DESC{ node.op.Get() } in DirectMLX.h
       "-Wno-missing-field-initializers",
+
+      # Allow third_party/onnxruntime/include/onnxruntime/core/common/status.h(115,9):
+      # use of the 'nodiscard' attribute is a C++17 extension
+      "-Wno-c++17-extensions",
     ]
   }
 }

--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -313,6 +313,50 @@ source_set("webnn_native_sources") {
       "${webnn_root}/third_party/XNNPACK/build/local/pthreadpool/${libfolder}/${libprefix}pthreadpool.${libext}",
     ]
   }
+
+  if (webnn_enable_mlas) {
+    sources += [
+      "mlas/ContextMLAS.cpp",
+      "mlas/ContextMLAS.h",
+      "mlas/GraphMLAS.cpp",
+      "mlas/GraphMLAS.h",
+    ]
+
+    include_dirs += [
+      "${webnn_root}/third_party/onnxruntime/onnxruntime/core/mlas/inc",
+      "${webnn_root}/third_party/onnxruntime/include/onnxruntime",
+      "${webnn_root}/third_party/onnxruntime/onnxruntime/",
+    ]
+
+    libprefix = ""
+    libext = ""
+    libfolder = ""
+    libos = ""
+
+    if (is_debug) {
+      libfolder = "Debug"
+    } else {
+      libfolder = "Release"
+    }
+
+    if (is_win) {
+      libext = "lib"
+      libos = "Windows"
+    }
+
+    if (is_linux) {
+      libprefix = "lib"
+      libext = "a"
+      libos = "Linux"
+    }
+
+    libs += [
+      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/${libfolder}/${libprefix}onnxruntime_mlas.${libext}",
+      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/${libfolder}/${libprefix}onnxruntime_common.${libext}",
+      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/external/pytorch_cpuinfo/${libfolder}/${libprefix}cpuinfo.${libext}",
+      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/external/pytorch_cpuinfo/deps/clog/${libfolder}/${libprefix}clog.${libext}",
+    ]
+  }
 }
 
 # The static and shared libraries for webnn_native. Most of the files are

--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -331,6 +331,7 @@ source_set("webnn_native_sources") {
     libprefix = ""
     libext = ""
     libfolder = ""
+    libsubfolder = ""
     libos = ""
 
     if (is_debug) {
@@ -342,6 +343,11 @@ source_set("webnn_native_sources") {
     if (is_win) {
       libext = "lib"
       libos = "Windows"
+      if (is_debug) {
+        libsubfolder = "Debug"
+      } else {
+        libsubfolder = "Release"
+      }
     }
 
     if (is_linux) {
@@ -351,11 +357,18 @@ source_set("webnn_native_sources") {
     }
 
     libs += [
-      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/${libfolder}/${libprefix}onnxruntime_mlas.${libext}",
-      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/${libfolder}/${libprefix}onnxruntime_common.${libext}",
-      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/external/pytorch_cpuinfo/${libfolder}/${libprefix}cpuinfo.${libext}",
-      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/external/pytorch_cpuinfo/deps/clog/${libfolder}/${libprefix}clog.${libext}",
+      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/${libsubfolder}/${libprefix}onnxruntime_mlas.${libext}",
+      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/${libsubfolder}/${libprefix}onnxruntime_common.${libext}",
+      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/external/pytorch_cpuinfo/${libsubfolder}/${libprefix}cpuinfo.${libext}",
+      "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/external/pytorch_cpuinfo/deps/clog/${libsubfolder}/${libprefix}clog.${libext}",
     ]
+
+    if (is_linux) {
+      libs += [
+        "${webnn_root}/third_party/onnxruntime/build/${libos}/${libfolder}/external/nsync/${libsubfolder}/${libprefix}nsync_cpp.${libext}",
+        "stdc++",
+      ]
+    }
   }
 }
 

--- a/src/webnn_native/Operand.h
+++ b/src/webnn_native/Operand.h
@@ -31,7 +31,7 @@ namespace webnn_native {
         OperandBase(GraphBuilderBase*, OperatorBase*);
         virtual ~OperandBase() = default;
 
-        const OperatorBase* Operator() {
+        const OperatorBase* Operator() const {
             return mOperator.Get();
         }
 

--- a/src/webnn_native/WebnnNative.cpp
+++ b/src/webnn_native/WebnnNative.cpp
@@ -68,6 +68,9 @@ namespace webnn_native {
     namespace xnnpack {
         ContextBase* Create();
     }
+    namespace mlas {
+        ContextBase* Create();
+    }
 
     // Should put the default null backend at the end.
     MLContext CreateContext(MLContextOptions const* options) {
@@ -85,6 +88,8 @@ namespace webnn_native {
         return reinterpret_cast<MLContext>(onednn::Create());
 #elif defined(WEBNN_ENABLE_BACKEND_XNNPACK)
         return reinterpret_cast<MLContext>(xnnpack::Create());
+#elif defined(WEBNN_ENABLE_BACKEND_MLAS)
+        return reinterpret_cast<MLContext>(mlas::Create());
 #elif defined(WEBNN_ENABLE_BACKEND_NULL)
         return reinterpret_cast<MLContext>(null::Create(options));
 #else

--- a/src/webnn_native/mlas/ContextMLAS.cpp
+++ b/src/webnn_native/mlas/ContextMLAS.cpp
@@ -37,8 +37,14 @@ namespace webnn_native { namespace mlas {
     }
 
     void Context::CreateThreadPool() {
+        std::vector<size_t> cpuList = onnxruntime::Env::Default().GetThreadAffinityMasks();
+        if (cpuList.empty() || cpuList.size() == 1)
+            return;
+        int threadPoolSize = static_cast<int>(cpuList.size());
+        onnxruntime::ThreadOptions options;
+        options.affinity = cpuList;
         mThreadPool = new onnxruntime::concurrency::ThreadPool(
-            &onnxruntime::Env::Default(), onnxruntime::ThreadOptions(), nullptr, 4, false);
+            &onnxruntime::Env::Default(), options, nullptr, threadPoolSize, false);
     }
 
     MLAS_THREADPOOL* Context::GetThreadPool() {

--- a/src/webnn_native/mlas/ContextMLAS.cpp
+++ b/src/webnn_native/mlas/ContextMLAS.cpp
@@ -1,0 +1,52 @@
+// Copyright 2021 The WebNN-native Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "webnn_native/mlas/ContextMLAS.h"
+
+#include "common/Log.h"
+#include "common/RefCounted.h"
+#include "webnn_native/mlas/GraphMLAS.h"
+
+#include <core/platform/threadpool.h>
+
+namespace webnn_native { namespace mlas {
+
+    ContextBase* Create() {
+        Ref<ContextBase> context = AcquireRef(new Context());
+        reinterpret_cast<Context*>(context.Get())->CreateThreadPool();
+        return context.Detach();
+    }
+
+    Context::Context() : mThreadPool(nullptr) {
+    }
+
+    Context::~Context() {
+        if (mThreadPool)
+            delete mThreadPool;
+    }
+
+    void Context::CreateThreadPool() {
+        mThreadPool = new onnxruntime::concurrency::ThreadPool(
+            &onnxruntime::Env::Default(), onnxruntime::ThreadOptions(), nullptr, 4, false);
+    }
+
+    MLAS_THREADPOOL* Context::GetThreadPool() {
+        return mThreadPool;
+    }
+
+    GraphBase* Context::CreateGraphImpl() {
+        return new Graph(this);
+    }
+
+}}  // namespace webnn_native::mlas

--- a/src/webnn_native/mlas/ContextMLAS.h
+++ b/src/webnn_native/mlas/ContextMLAS.h
@@ -1,0 +1,41 @@
+// Copyright 2021 The WebNN-native Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WEBNN_NATIVE_MLAS_CONTEXT_MLAS_H_
+#define WEBNN_NATIVE_MLAS_CONTEXT_MLAS_H_
+
+#include "webnn_native/Context.h"
+
+#include <mlas.h>
+
+namespace webnn_native { namespace mlas {
+
+    class Context : public ContextBase {
+      public:
+        Context();
+        ~Context() override;
+
+        void CreateThreadPool();
+
+        MLAS_THREADPOOL* GetThreadPool();
+
+      private:
+        GraphBase* CreateGraphImpl() override;
+
+        MLAS_THREADPOOL* mThreadPool;
+    };
+
+}}  // namespace webnn_native::mlas
+
+#endif  // WEBNN_NATIVE_MLAS_CONTEXT_MLAS_H_

--- a/src/webnn_native/mlas/GraphMLAS.cpp
+++ b/src/webnn_native/mlas/GraphMLAS.cpp
@@ -1,0 +1,1015 @@
+// Copyright 2021 The WebNN-native Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "webnn_native/mlas/GraphMLAS.h"
+
+#include <mlas.h>
+
+#include <numeric>
+
+#include "common/Assert.h"
+#include "common/Log.h"
+#include "webnn_native/ErrorData.h"
+#include "webnn_native/NamedInputs.h"
+#include "webnn_native/NamedOutputs.h"
+#include "webnn_native/Operand.h"
+#include "webnn_native/Utils.h"
+
+#define VERBOSE 0
+
+namespace webnn_native { namespace mlas {
+
+    void* AlignedAlloc(size_t size) {
+        if (size <= 0)
+            return nullptr;
+        void* p;
+        size_t alignment = MlasGetPreferredBufferAlignment();
+#if _MSC_VER
+        p = _aligned_malloc(size, alignment);
+#elif defined(_LIBCPP_SGX_CONFIG)
+        p = memalign(alignment, size);
+#else
+        posix_memalign(&p, alignment, size);
+#endif
+        return p;
+    }
+
+    void AlignedFree(void* p) {
+#if _MSC_VER
+        _aligned_free(p);
+#else
+        free(p);
+#endif
+    }
+
+    class Memory : public RefCounted {
+      public:
+        explicit Memory(ml::OperandType type,
+                        const std::vector<int32_t>& dims,
+                        bool blockedLayout = false)
+            : mType(type), mDimensions(dims), mBuffer(nullptr), mBlockedLayout(blockedLayout) {
+        }
+
+        ~Memory() {
+            if (mBuffer) {
+                AlignedFree(mBuffer);
+            }
+        };
+
+        bool Allocate() {
+            size_t elementNum = std::accumulate(mDimensions.begin(), mDimensions.end(), (size_t)1,
+                                                std::multiplies<size_t>{});
+            size_t elementSize;
+            switch (mType) {
+                case ml::OperandType::Float32:
+                    elementSize = sizeof(float);
+                    break;
+                case ml::OperandType::Float16:
+                    elementSize = sizeof(int16_t);
+                    break;
+                case ml::OperandType::Int32:
+                    elementSize = sizeof(int32_t);
+                    break;
+                case ml::OperandType::Uint32:
+                    elementSize = sizeof(uint32_t);
+                    break;
+                case ml::OperandType::Int8:
+                    elementSize = sizeof(int8_t);
+                    break;
+                case ml::OperandType::Uint8:
+                    elementSize = sizeof(uint8_t);
+                    break;
+                default:
+                    return false;
+            }
+            mByteLength = elementNum * elementSize;
+            mBuffer = AlignedAlloc(mByteLength);
+            return mBuffer != nullptr;
+        }
+
+        ml::OperandType GetType() {
+            return mType;
+        }
+        std::vector<int32_t> GetDimensions() {
+            return mDimensions;
+        }
+        void* GetBuffer() {
+            return mBuffer;
+        }
+        size_t GetByteLength() {
+            return mByteLength;
+        }
+        bool IsBlockedLayout() {
+            return mBlockedLayout;
+        }
+
+      private:
+        ml::OperandType mType;
+        std::vector<int32_t> mDimensions;
+        void* mBuffer;
+        size_t mByteLength;
+        bool mBlockedLayout;
+    };
+
+    class Kernel : public RefCounted {
+      public:
+        Kernel() = default;
+        virtual ~Kernel() = default;
+
+        virtual void Compute(MLAS_THREADPOOL* threadPool = nullptr) = 0;
+    };
+
+    class Clamp : public Kernel {
+      public:
+        Clamp(const Ref<Memory>& input,
+              const Ref<Memory>& output,
+              size_t elementNum,
+              MLAS_ACTIVATION actition)
+            : mInput(input), mOutput(output), mElementNum(elementNum), mActivation(actition) {
+        }
+        virtual ~Clamp() = default;
+
+        virtual void Compute(MLAS_THREADPOOL* threadPool = nullptr) {
+            const float* input = reinterpret_cast<const float*>(mInput->GetBuffer());
+            float* output = reinterpret_cast<float*>(mOutput->GetBuffer());
+            memcpy(output, input, mElementNum * sizeof(float));
+            MlasActivation(&mActivation, output, nullptr, 1, mElementNum, mElementNum);
+        }
+
+      private:
+        Ref<Memory> mInput;
+        Ref<Memory> mOutput;
+        size_t mElementNum;
+        MLAS_ACTIVATION mActivation;
+    };
+
+    class Unary : public Kernel {
+      public:
+        Unary(op::UnaryOpType opType,
+              const Ref<Memory>& input,
+              const Ref<Memory>& output,
+              size_t elementNum,
+              MLAS_ACTIVATION activation)
+            : mOpType(opType),
+              mInput(input),
+              mOutput(output),
+              mElementNum(elementNum),
+              mActivation(activation) {
+        }
+        virtual ~Unary() = default;
+
+        virtual void Compute(MLAS_THREADPOOL* threadPool = nullptr) {
+            const float* input = reinterpret_cast<const float*>(mInput->GetBuffer());
+            float* output = reinterpret_cast<float*>(mOutput->GetBuffer());
+            if (mOpType == op::UnaryOpType::kSigmoid) {
+                MlasComputeLogistic(input, output, mElementNum);
+            } else if (mOpType == op::UnaryOpType::kSoftmax) {
+                MlasComputeSoftmax(input, output, mInput->GetDimensions()[0],
+                                   mInput->GetDimensions()[1], false, threadPool);
+            } else if (mOpType == op::UnaryOpType::kExp) {
+                MlasComputeExp(input, output, mElementNum);
+            } else if (mOpType == op::UnaryOpType::kTanh) {
+                MlasComputeTanh(input, output, mElementNum);
+            } else if (mOpType == op::UnaryOpType::kRelu ||
+                       mOpType == op::UnaryOpType::kHardSwish ||
+                       mOpType == op::UnaryOpType::kLeakyRelu) {
+                memcpy(output, input, mElementNum * sizeof(float));
+                MlasActivation(&mActivation, output, nullptr, 1, mElementNum, mElementNum);
+            } else {
+                DAWN_UNREACHABLE();
+            }
+        }
+
+      private:
+        op::UnaryOpType mOpType;
+        Ref<Memory> mInput;
+        Ref<Memory> mOutput;
+        size_t mElementNum;
+        MLAS_ACTIVATION mActivation;
+    };
+
+    class ReorderInput : public Kernel {
+      public:
+        ReorderInput(const Ref<Memory>& input,
+                     const Ref<Memory>& output,
+                     size_t inputChannels,
+                     size_t inputSize)
+            : mInput(input),
+              mOutput(output),
+              mInputChannels(inputChannels),
+              mInputSize(inputSize){};
+
+        virtual ~ReorderInput() = default;
+
+        virtual void Compute(MLAS_THREADPOOL* threadPool = nullptr) {
+            const float* input = reinterpret_cast<const float*>(mInput->GetBuffer());
+            float* output = reinterpret_cast<float*>(mOutput->GetBuffer());
+#if (VERBOSE)
+            dawn::InfoLog() << "MlasReorderInputNchw";
+            dawn::InfoLog() << "    input: " << input << " output: " << output;
+            dawn::InfoLog() << "    input channels: " << mInputChannels;
+            dawn::InfoLog() << "    input size: " << mInputSize;
+#endif
+            MlasReorderInputNchw(input, output, mInputChannels, mInputSize);
+        }
+
+      private:
+        Ref<Memory> mInput;
+        Ref<Memory> mOutput;
+        size_t mInputChannels;
+        size_t mInputSize;
+    };
+
+    class ReorderOutput : public Kernel {
+      public:
+        ReorderOutput(const Ref<Memory>& input,
+                      const Ref<Memory>& output,
+                      const std::vector<int64_t>& outputShape)
+            : mInput(input), mOutput(output), mOutputShape(outputShape) {
+        }
+
+        virtual ~ReorderOutput() = default;
+
+        virtual void Compute(MLAS_THREADPOOL* threadPool = nullptr) {
+            const float* input = reinterpret_cast<const float*>(mInput->GetBuffer());
+            float* output = reinterpret_cast<float*>(mOutput->GetBuffer());
+#if (VERBOSE)
+            dawn::InfoLog() << "MlasReorderOutputNchw";
+            dawn::InfoLog() << "    input: " << input << " output: " << output;
+            dawn::InfoLog() << "    output shape: [" << mOutputShape[0] << ", " << mOutputShape[1]
+                            << ", " << mOutputShape[2] << ", " << mOutputShape[3] << "]";
+#endif
+            MlasReorderOutputNchw(mOutputShape.data(), input, output);
+        }
+
+      private:
+        Ref<Memory> mInput;
+        Ref<Memory> mOutput;
+        std::vector<int64_t> mOutputShape;
+    };
+
+    class Conv2d : public Kernel {
+      public:
+        Conv2d(bool nchwcConv,
+               const Ref<Memory>& input,
+               const Ref<Memory>& filter,
+               const Ref<Memory>& bias,
+               const Ref<Memory>& output,
+               const std::vector<int64_t>& inputShape,
+               const std::vector<int64_t>& kernelShape,
+               const std::vector<int64_t>& dilationShape,
+               const std::vector<int64_t>& padding,
+               const std::vector<int64_t>& strideShape,
+               const std::vector<int64_t>& outputShape,
+               size_t groupCount,
+               MLAS_ACTIVATION activation)
+            : nchwcConv(nchwcConv),
+              mInput(input),
+              mFilter(filter),
+              mBias(bias),
+              mOutput(output),
+              mInputShape(inputShape),
+              mKernelShape(kernelShape),
+              mDilationShape(dilationShape),
+              mPadding(padding),
+              mStrideShape(strideShape),
+              mOutputShape(outputShape),
+              mGroupCount(groupCount),
+              mActivation(activation),
+              mZeroMode(true) {
+        }
+
+        virtual ~Conv2d() = default;
+
+        bool Prepare(MLAS_THREADPOOL* threadPool = nullptr) {
+            DAWN_ASSERT(!nchwcConv);
+            size_t workingBufferSize;
+            size_t dimensions = 2;
+            size_t batchCount = mInputShape[0];
+            size_t inputChannels = mInputShape[1];
+            size_t outputChannels = mOutputShape[1];
+            std::vector<int64_t> inputShape = {mInputShape[2], mInputShape[3]};
+            std::vector<int64_t> outputShape = {mOutputShape[2], mOutputShape[3]};
+            MlasConvPrepare(&mParameters, dimensions, batchCount, mGroupCount,
+                            inputChannels / mGroupCount, inputShape.data(), mKernelShape.data(),
+                            mDilationShape.data(), mPadding.data(), mStrideShape.data(),
+                            outputShape.data(), outputChannels / mGroupCount, &mActivation,
+                            &workingBufferSize, threadPool);
+            if (workingBufferSize > 0) {
+                mWorkingBuffer =
+                    AcquireRef(new Memory(ml::OperandType::Float32, {int32_t(workingBufferSize)}));
+                if (!mWorkingBuffer->Allocate()) {
+                    dawn::ErrorLog() << "Failed to allocate working buffer";
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        virtual void Compute(MLAS_THREADPOOL* threadPool = nullptr) {
+            const float* input = reinterpret_cast<const float*>(mInput->GetBuffer());
+            const float* filter = reinterpret_cast<const float*>(mFilter->GetBuffer());
+            const float* bias =
+                mBias.Get() ? reinterpret_cast<const float*>(mBias->GetBuffer()) : nullptr;
+            float* output = reinterpret_cast<float*>(mOutput->GetBuffer());
+            if (!nchwcConv) {
+                float* workingBuffer = mWorkingBuffer.Get()
+                                           ? reinterpret_cast<float*>(mWorkingBuffer->GetBuffer())
+                                           : nullptr;
+                MlasConv(&mParameters, input, filter, bias, workingBuffer, output, threadPool);
+            } else {
+                MlasNchwcConv(mInputShape.data(), mKernelShape.data(), mDilationShape.data(),
+                              mPadding.data(), mStrideShape.data(), mOutputShape.data(),
+                              mGroupCount, input, filter, bias, output, &mActivation, mZeroMode,
+                              threadPool);
+            }
+#if (VERBOSE)
+            nchwcConv ? dawn::InfoLog() << "MlasNchwcConv" : dawn::InfoLog() << "MlasConv";
+            dawn::InfoLog() << "    input: " << input << " output: " << output;
+            dawn::InfoLog() << "    input shape: [" << mInputShape[0] << ", " << mInputShape[1]
+                            << ", " << mInputShape[2] << ", " << mInputShape[3] << "]";
+            dawn::InfoLog() << "    kernel shape: [" << mKernelShape[0] << ", " << mKernelShape[1]
+                            << "]";
+            dawn::InfoLog() << "    output shape: [" << mOutputShape[0] << ", " << mOutputShape[1]
+                            << ", " << mOutputShape[2] << ", " << mOutputShape[3] << "]";
+            dawn::InfoLog() << "    group count: " << mGroupCount;
+            dawn::InfoLog() << "    activation: " << mActivation.ActivationKind;
+            dawn::InfoLog() << "    zero mode: " << mZeroMode;
+#endif
+        }
+
+      private:
+        friend class Graph;
+        bool nchwcConv;
+        Ref<Memory> mInput;
+        Ref<Memory> mFilter;
+        Ref<Memory> mBias;
+        Ref<Memory> mWorkingBuffer;
+        Ref<Memory> mOutput;
+        MLAS_CONV_PARAMETERS mParameters;
+        std::vector<int64_t> mInputShape;
+        std::vector<int64_t> mKernelShape;
+        std::vector<int64_t> mDilationShape;
+        std::vector<int64_t> mPadding;
+        std::vector<int64_t> mStrideShape;
+        std::vector<int64_t> mOutputShape;
+        size_t mGroupCount;
+        MLAS_ACTIVATION mActivation;
+        bool mZeroMode;
+    };
+
+    class Pool2d : public Kernel {
+      public:
+        Pool2d(MLAS_POOLING_KIND kind,
+               bool global,
+               const Ref<Memory>& input,
+               const Ref<Memory>& output,
+               const std::vector<int64_t>& inputShape,
+               const std::vector<int64_t>& kernelShape,
+               const std::vector<int64_t>& dilationShape,
+               const std::vector<int64_t>& padding,
+               const std::vector<int64_t>& strideShape,
+               const std::vector<int64_t>& outputShape)
+            : mKind(kind),
+              mGlobal(global),
+              mInput(input),
+              mOutput(output),
+              mInputShape(inputShape),
+              mKernelShape(kernelShape),
+              mDilationShape(dilationShape),
+              mPadding(padding),
+              mStrideShape(strideShape),
+              mOutputShape(outputShape) {
+        }
+
+        virtual ~Pool2d() = default;
+
+        virtual void Compute(MLAS_THREADPOOL* threadPool = nullptr) {
+            const float* input = reinterpret_cast<const float*>(mInput->GetBuffer());
+            float* output = reinterpret_cast<float*>(mOutput->GetBuffer());
+            MlasNchwcPool(mKind, mInputShape.data(), mGlobal ? nullptr : mKernelShape.data(),
+                          mGlobal ? nullptr : mDilationShape.data(),
+                          mGlobal ? nullptr : mPadding.data(),
+                          mGlobal ? nullptr : mStrideShape.data(), mOutputShape.data(), input,
+                          output, threadPool);
+#if (VERBOSE)
+            dawn::InfoLog() << "MlasNchwcPool";
+            dawn::InfoLog() << "    kind: " << mKind;
+            dawn::InfoLog() << "    global: " << mGlobal;
+            dawn::InfoLog() << "    input: " << input << " output: " << output;
+            dawn::InfoLog() << "    input shape: [" << mInputShape[0] << ", " << mInputShape[1]
+                            << ", " << mInputShape[2] << ", " << mInputShape[3] << "]";
+            dawn::InfoLog() << "    kernel shape: [" << mKernelShape[0] << ", " << mKernelShape[1]
+                            << "]";
+            dawn::InfoLog() << "    output shape: [" << mOutputShape[0] << ", " << mOutputShape[1]
+                            << ", " << mOutputShape[2] << ", " << mOutputShape[3] << "]";
+#endif
+        }
+
+      private:
+        friend class Graph;
+        MLAS_POOLING_KIND mKind;
+        bool mGlobal;
+        Ref<Memory> mInput;
+        Ref<Memory> mOutput;
+        std::vector<int64_t> mInputShape;
+        std::vector<int64_t> mKernelShape;
+        std::vector<int64_t> mDilationShape;
+        std::vector<int64_t> mPadding;
+        std::vector<int64_t> mStrideShape;
+        std::vector<int64_t> mOutputShape;
+    };
+
+    Graph::Graph(Context* context) : GraphBase(context) {
+    }
+
+    Graph::~Graph() {
+    }
+
+    MaybeError Graph::AddConstant(const op::Constant* constant) {
+        const OperandBase* operand = constant->PrimaryOutput();
+        Ref<Memory> memory = AcquireRef(new Memory(operand->Type(), operand->Shape()));
+        if (!memory->Allocate()) {
+            return DAWN_INTERNAL_ERROR("Failed to allocate memory.");
+        }
+        memcpy(memory->GetBuffer(), constant->GetBuffer(), constant->GetByteLength());
+        mMemoryMap.insert(std::make_pair(operand, memory));
+#if (VERBOSE)
+        dawn::InfoLog() << "add constant memory: " << memory.Get();
+#endif
+        return {};
+    }
+
+    MaybeError Graph::AddInput(const op::Input* input) {
+        const OperandBase* operand = input->PrimaryOutput();
+        Ref<Memory> memory = AcquireRef(new Memory(operand->Type(), operand->Shape()));
+        if (!memory->Allocate()) {
+            return DAWN_INTERNAL_ERROR("Failed to allocate memory.");
+        }
+        mMemoryMap.insert(std::make_pair(operand, memory));
+        mInputs.insert(std::make_pair(input->GetName(), memory));
+#if (VERBOSE)
+        dawn::InfoLog() << "add input memory: " << memory.Get();
+#endif
+        return {};
+    }
+
+    MaybeError Graph::AddOutput(const std::string& name, const OperandBase* output) {
+        DAWN_ASSERT(mMemoryMap.find(output) != mMemoryMap.end());
+        Ref<Memory> memory = mMemoryMap.at(output);
+        if (memory->IsBlockedLayout()) {
+            // ReorderOutput
+            const size_t rank = output->Shape().size();
+            if (rank != 4) {
+                return DAWN_INTERNAL_ERROR("NCHWc memory layout only supports rank 4.");
+            }
+            int32_t channels = output->Shape()[1];
+            DAWN_ASSERT(channels <= memory->GetDimensions()[1]);
+            Ref<Memory> nchwMemory = AcquireRef(new Memory(output->Type(), output->Shape()));
+            if (!nchwMemory->Allocate()) {
+                return DAWN_INTERNAL_ERROR("Failed to allocate output memory.");
+            }
+            std::vector<int64_t> outputShape = {output->Shape()[0], output->Shape()[1],
+                                                output->Shape()[2], output->Shape()[3]};
+            mKernels.push_back(AcquireRef(new ReorderOutput(memory, nchwMemory, outputShape)));
+            memory = nchwMemory;
+        }
+        mOutputs.insert(std::make_pair(name, memory));
+        return {};
+    }
+
+    MaybeError Graph::AddClamp(const op::Clamp* clamp) {
+        const OperandBase* inputOperand = clamp->Inputs()[0].Get();
+        if (inputOperand->Type() != ml::OperandType::Float32) {
+            return DAWN_INTERNAL_ERROR("Only support float32");
+        }
+        DAWN_ASSERT(mMemoryMap.find(inputOperand) != mMemoryMap.end());
+        Ref<Memory> inputMemory = mMemoryMap.at(inputOperand);
+        const OperandBase* outputOperand = clamp->PrimaryOutput();
+        Ref<Memory> outputMemory =
+            AcquireRef(new Memory(outputOperand->Type(), outputOperand->Shape()));
+        if (!outputMemory->Allocate()) {
+            return DAWN_INTERNAL_ERROR("Failed to allocate output memory");
+        }
+        mMemoryMap.insert(std::make_pair(outputOperand, outputMemory));
+        std::vector<int32_t> dimensions = inputOperand->Shape();
+        size_t elementNum = std::accumulate(dimensions.begin(), dimensions.end(), (size_t)1,
+                                            std::multiplies<size_t>{});
+        MLAS_ACTIVATION activation;
+        activation.ActivationKind = MlasClipActivation;
+        activation.Parameters.Clip.minimum = clamp->GetMinValue();
+        activation.Parameters.Clip.maximum = clamp->GetMaxValue();
+        mKernels.push_back(
+            AcquireRef(new Clamp(inputMemory, outputMemory, elementNum, activation)));
+        return {};
+    }
+
+    MaybeError Graph::AddBinary(const op::Binary* binary) {
+        if (binary->GetType() != op::BinaryOpType::kAdd) {
+            return DAWN_UNIMPLEMENTED_ERROR("Binary op is unimplemented.");
+        }
+        const OperandBase* a = binary->Inputs()[0].Get();
+        if (a->Type() != ml::OperandType::Float32) {
+            return DAWN_INTERNAL_ERROR("Only support float32 input.");
+        }
+        const OperandBase* b = binary->Inputs()[1].Get();
+        if (b->Type() != ml::OperandType::Float32) {
+            return DAWN_INTERNAL_ERROR("Only support float32 input.");
+        }
+        if (a->Shape() != b->Shape()) {
+            return DAWN_INTERNAL_ERROR("Shapes don't match.");
+        }
+        DAWN_ASSERT(mMemoryMap.find(a) != mMemoryMap.end());
+        Ref<Memory> aMemory = mMemoryMap.at(a);
+        if (!aMemory->IsBlockedLayout()) {
+            return DAWN_INTERNAL_ERROR("Only support blocked memory.");
+        }
+        DAWN_ASSERT(mMemoryMap.find(b) != mMemoryMap.end());
+        Ref<Memory> bMemory = mMemoryMap.at(b);
+        if (!bMemory->IsBlockedLayout()) {
+            return DAWN_INTERNAL_ERROR("Only support blocked memory.");
+        }
+#if (VERBOSE)
+        dawn::InfoLog() << "Add add";
+        dawn::InfoLog() << "    a: " << a->Operator();
+        dawn::InfoLog() << "    b: " << b->Operator();
+#endif
+        Ref<Conv2d> aConv2d;
+        if (mConv2dKernels.find(a->Operator()) != mConv2dKernels.end()) {
+            aConv2d = mConv2dKernels.at(a->Operator());
+        }
+        Ref<Conv2d> bConv2d;
+        if (mConv2dKernels.find(b->Operator()) != mConv2dKernels.end()) {
+            bConv2d = mConv2dKernels.at(b->Operator());
+        }
+        if (aConv2d.Get() == nullptr && bConv2d.Get() == nullptr) {
+            return DAWN_INTERNAL_ERROR("At least one operand should be conv2d.");
+        }
+        Ref<Conv2d> conv2d;
+        if (aConv2d.Get() != nullptr && bConv2d.Get() != nullptr) {
+            size_t aKernelIndex = 0;
+            for (; aKernelIndex < mKernels.size(); ++aKernelIndex) {
+                if (mKernels[aKernelIndex].Get() == aConv2d.Get()) {
+                    break;
+                }
+            }
+            size_t bKernelIndex = 0;
+            for (; bKernelIndex < mKernels.size(); ++bKernelIndex) {
+                if (mKernels[bKernelIndex].Get() == bConv2d.Get()) {
+                    break;
+                }
+            }
+            if (aKernelIndex > bKernelIndex) {
+                aConv2d->mOutput = bConv2d->mOutput;
+                conv2d = aConv2d;
+            } else {
+                bConv2d->mOutput = aConv2d->mOutput;
+                conv2d = bConv2d;
+            }
+        } else if (aConv2d.Get() != nullptr) {
+            aConv2d->mOutput = bMemory;
+            conv2d = aConv2d;
+        } else {
+            bConv2d->mOutput = aMemory;
+            conv2d = bConv2d;
+        }
+        conv2d->mZeroMode = false;
+        const OperandBase* output = binary->PrimaryOutput();
+        mMemoryMap.insert(std::make_pair(output, conv2d->mOutput));
+        return {};
+    }
+
+    MaybeError Graph::AddConv2d(const op::Conv2d* conv2d) {
+        const Conv2dOptions* options = conv2d->GetOptions();
+        if (options->inputLayout != ml::InputOperandLayout::Nchw) {
+            return DAWN_INTERNAL_ERROR("Only support nchw input layout");
+        }
+        if (options->filterLayout != ml::FilterOperandLayout::Oihw) {
+            return DAWN_INTERNAL_ERROR("Only support iohw filter layout");
+        }
+        const OperandBase* inputOperand = conv2d->Inputs()[0].Get();
+        if (inputOperand->Type() != ml::OperandType::Float32) {
+            return DAWN_INTERNAL_ERROR("Only support float32 input");
+        }
+        const OperandBase* filterOperand = conv2d->Inputs()[1].Get();
+        if (filterOperand->Type() != ml::OperandType::Float32) {
+            return DAWN_INTERNAL_ERROR("Only support float32 filter");
+        }
+        size_t groupCount = options->groups;
+        size_t batchCount = inputOperand->Shape()[0];
+        size_t inputChannels = inputOperand->Shape()[1];
+        size_t outputChannels = filterOperand->Shape()[0];
+        int32_t inputHeight = inputOperand->Shape()[2];
+        int32_t inputWidth = inputOperand->Shape()[3];
+        int32_t filterHeight = filterOperand->Shape()[2];
+        int32_t filterWidth = filterOperand->Shape()[3];
+        std::vector<int64_t> inputShape = {inputOperand->Shape()[0], inputOperand->Shape()[1],
+                                           inputOperand->Shape()[2], inputOperand->Shape()[3]};
+        std::vector<int64_t> kernelShape = {filterOperand->Shape()[2], filterOperand->Shape()[3]};
+        std::vector<int64_t> dilationShape = {options->dilations[0], options->dilations[1]};
+        int32_t paddingBeginningHeight = options->padding[0],
+                paddingEndingHeight = options->padding[1],
+                paddingBeginningWidth = options->padding[2],
+                paddingEndingWidth = options->padding[3];
+        if (options->autoPad != ml::AutoPad::Explicit) {
+            utils::ComputeImplicitPaddingForAutoPad(options->autoPad, options->dilations[0],
+                                                    inputHeight, filterHeight, options->strides[0],
+                                                    paddingBeginningHeight, paddingEndingHeight);
+            utils::ComputeImplicitPaddingForAutoPad(options->autoPad, options->dilations[1],
+                                                    inputWidth, filterWidth, options->strides[1],
+                                                    paddingBeginningWidth, paddingEndingWidth);
+        }
+        std::vector<int64_t> padding = {paddingBeginningHeight, paddingEndingHeight,
+                                        paddingBeginningWidth, paddingEndingWidth};
+        std::vector<int64_t> strideShape = {options->strides[0], options->strides[1]};
+        const OperandBase* outputOperand = conv2d->PrimaryOutput();
+        std::vector<int64_t> outputShape = {outputOperand->Shape()[0], outputOperand->Shape()[1],
+                                            outputOperand->Shape()[2], outputOperand->Shape()[3]};
+
+        size_t nchwcBlockSize = MlasNchwcGetBlockSize();
+        bool nchwcConv = nchwcBlockSize > 1 ? true : false;
+        bool reorderInput = true;
+        bool reorderFilterOIHWBo = false;
+        int64_t filterInputChannels = filterOperand->Shape()[1];
+        ;
+        int64_t nchwcGroupCount = groupCount;
+
+        // The current implementation of ReorderInput requires the channel count to be
+        // aligned to this value.
+        constexpr int64_t channelAlignment = 4;
+        const int64_t nchwcInputChannels =
+            (inputChannels + nchwcBlockSize - 1) & ~(nchwcBlockSize - 1);
+        const int64_t nchwcOutputChannels =
+            (outputChannels + nchwcBlockSize - 1) & ~(nchwcBlockSize - 1);
+
+        if (nchwcConv) {
+            if (groupCount > 1) {
+                if ((outputChannels % channelAlignment) != 0) {
+                    nchwcConv = false;
+                }
+                if (filterInputChannels == 1 && outputChannels == groupCount) {
+                    // Depthwise convolution.
+                    reorderFilterOIHWBo = true;
+                    nchwcGroupCount = nchwcOutputChannels;
+                } else if (((inputChannels % nchwcBlockSize) != 0) ||
+                           ((outputChannels % groupCount) != 0) ||
+                           (((outputChannels / groupCount) % nchwcBlockSize) != 0)) {
+                    nchwcConv = false;
+                }
+            } else {
+                if (static_cast<size_t>(inputChannels) < nchwcBlockSize) {
+                    // Use NCHW input buffer directly.
+                    reorderFilterOIHWBo = true;
+                    reorderInput = false;
+                } else {
+                    if ((inputChannels % channelAlignment) != 0) {
+                        nchwcConv = false;
+                    }
+                    filterInputChannels =
+                        (inputChannels + nchwcBlockSize - 1) & ~(nchwcBlockSize - 1);
+                }
+            }
+        }
+
+        DAWN_ASSERT(mMemoryMap.find(inputOperand) != mMemoryMap.end());
+        Ref<Memory> inputMemory = mMemoryMap.at(inputOperand);
+        if (nchwcConv && reorderInput) {
+            if (!inputMemory->IsBlockedLayout()) {
+                Ref<Memory> reorderInputMemory = inputMemory;
+                std::vector<int32_t> reorderedOutputShape = {
+                    static_cast<int32_t>(batchCount), static_cast<int32_t>(nchwcInputChannels),
+                    inputHeight, inputWidth};
+                Ref<Memory> reorderOutputMemory =
+                    AcquireRef(new Memory(inputOperand->Type(), reorderedOutputShape, true));
+                if (!reorderOutputMemory->Allocate()) {
+                    return DAWN_INTERNAL_ERROR("Failed to allocate reorder output memory.");
+                }
+                size_t inputSize = inputHeight * inputWidth;
+                mKernels.push_back(AcquireRef(new ReorderInput(
+                    reorderInputMemory, reorderOutputMemory, inputChannels, inputSize)));
+                inputMemory = reorderOutputMemory;
+                inputShape[1] = nchwcInputChannels;
+            } else {
+                inputShape[1] = inputMemory->GetDimensions()[1];
+            }
+        }
+
+        DAWN_ASSERT(mMemoryMap.find(filterOperand) != mMemoryMap.end());
+        Ref<Memory> filterMemory = mMemoryMap.at(filterOperand);
+        if (nchwcConv && !filterMemory->IsBlockedLayout()) {
+            std::vector<int32_t> reorderedFilterShape = {static_cast<int32_t>(nchwcOutputChannels),
+                                                         static_cast<int32_t>(filterInputChannels),
+                                                         filterHeight, filterWidth};
+            Ref<Memory> reorderedFilterMemory =
+                AcquireRef(new Memory(filterOperand->Type(), reorderedFilterShape, true));
+            if (!reorderedFilterMemory->Allocate()) {
+                return DAWN_INTERNAL_ERROR("Failed to allocate reorder output memory.");
+            }
+            std::vector<int64_t> filterShape = {
+                filterOperand->Shape()[0], filterOperand->Shape()[1], filterOperand->Shape()[2],
+                filterOperand->Shape()[3]};
+            const float* filterData = reinterpret_cast<const float*>(filterMemory->GetBuffer());
+            float* reorderdFilterData =
+                reinterpret_cast<float*>(reorderedFilterMemory->GetBuffer());
+            if (reorderFilterOIHWBo) {
+                MlasReorderFilterOIHWBo(filterShape.data(), filterData, reorderdFilterData);
+            } else {
+                MlasReorderFilterOIHWBiBo(filterShape.data(), filterData, reorderdFilterData);
+            }
+            filterMemory = reorderedFilterMemory;
+        }
+        Ref<Memory> biasMemory;
+        if (options->bias) {
+            const OperandBase* biasOperand = conv2d->Inputs()[2].Get();
+            if (biasOperand->Type() != ml::OperandType::Float32) {
+                return DAWN_INTERNAL_ERROR("Only support float32 bias");
+            }
+            DAWN_ASSERT(mMemoryMap.find(biasOperand) != mMemoryMap.end());
+            biasMemory = mMemoryMap.at(biasOperand);
+            if (nchwcConv && !biasMemory->IsBlockedLayout()) {
+                std::vector<int32_t> alignedBiasShape = {static_cast<int32_t>(nchwcOutputChannels)};
+                Ref<Memory> alignedBiasMemory =
+                    AcquireRef(new Memory(biasOperand->Type(), alignedBiasShape, true));
+                if (!alignedBiasMemory->Allocate()) {
+                    return DAWN_INTERNAL_ERROR("Failed to allocate reorder output memory.");
+                }
+                memcpy(alignedBiasMemory->GetBuffer(), biasMemory->GetBuffer(),
+                       biasMemory->GetByteLength());
+                biasMemory = alignedBiasMemory;
+            }
+        }
+
+        MLAS_ACTIVATION activation;
+        activation.ActivationKind = MlasIdentityActivation;
+        if (options->activation) {
+            switch (options->activation->GetFusedOperator()) {
+                case FusedOperator::Clamp:
+                    activation.ActivationKind = MlasClipActivation;
+                    activation.Parameters.Clip.minimum =
+                        reinterpret_cast<op::Clamp*>(options->activation)->GetMinValue();
+                    activation.Parameters.Clip.maximum =
+                        reinterpret_cast<op::Clamp*>(options->activation)->GetMaxValue();
+                    break;
+                case FusedOperator::HardSwish:
+                    activation.ActivationKind = MlasHardSigmoidActivation;
+                    activation.Parameters.HardSigmoid.alpha = 1.0 / 6.0;
+                    activation.Parameters.HardSigmoid.beta = 0.5;
+                    break;
+                case FusedOperator::Relu:
+                    activation.ActivationKind = MlasReluActivation;
+                    break;
+                case FusedOperator::Sigmoid:
+                    activation.ActivationKind = MlasLogisticActivation;
+                    break;
+                case FusedOperator::LeakyRelu:
+                    activation.ActivationKind = MlasLeakyReluActivation;
+                    activation.Parameters.LeakyRelu.alpha =
+                        reinterpret_cast<op::LeakyRelu*>(options->activation)->GetAlpha();
+                    break;
+                default:
+                    return DAWN_INTERNAL_ERROR("Unsupported fused activation");
+            }
+        }
+
+        Ref<Memory> outputMemory;
+        if (!nchwcConv) {
+            outputMemory = AcquireRef(new Memory(outputOperand->Type(), outputOperand->Shape()));
+        } else {
+            std::vector<int32_t> nchwcOutputShape = {
+                outputOperand->Shape()[0], static_cast<int32_t>(nchwcOutputChannels),
+                outputOperand->Shape()[2], outputOperand->Shape()[3]};
+            outputMemory = AcquireRef(new Memory(outputOperand->Type(), nchwcOutputShape, true));
+            outputShape[1] = nchwcOutputChannels;
+        }
+        if (!outputMemory->Allocate()) {
+            return DAWN_INTERNAL_ERROR("Failed to allocate output memory");
+        }
+        mMemoryMap.insert(std::make_pair(outputOperand, outputMemory));
+
+        Ref<Conv2d> kernel = AcquireRef(new Conv2d(
+            nchwcConv, inputMemory, filterMemory, biasMemory, outputMemory, inputShape, kernelShape,
+            dilationShape, padding, strideShape, outputShape, nchwcGroupCount, activation));
+        if (!nchwcConv) {
+            if (!kernel->Prepare(reinterpret_cast<Context*>(GetContext())->GetThreadPool())) {
+                return DAWN_INTERNAL_ERROR("Failed to prepare conv2d.");
+            }
+        }
+#if (VERBOSE)
+        dawn::InfoLog() << "Add conv2d " << conv2d << " kernel " << kernel.Get();
+        dawn::InfoLog() << "    input memory: " << inputMemory.Get();
+        dawn::InfoLog() << "    output memory: " << outputMemory.Get();
+#endif
+        mKernels.push_back(kernel);
+        mConv2dKernels.insert(std::make_pair(conv2d, kernel));
+        return {};
+    }
+
+    MaybeError Graph::AddPool2d(const op::Pool2d* pool2d) {
+        const Pool2dOptions* options = pool2d->GetOptions();
+        if (options->layout != ml::InputOperandLayout::Nchw) {
+            return DAWN_INTERNAL_ERROR("Only support nchw input layout");
+        }
+        const OperandBase* inputOperand = pool2d->Inputs()[0].Get();
+        if (inputOperand->Type() != ml::OperandType::Float32) {
+            return DAWN_INTERNAL_ERROR("Only support float32 input");
+        }
+        size_t nchwcBlockSize = MlasNchwcGetBlockSize();
+        bool nchwcPool = nchwcBlockSize > 1 ? true : false;
+
+        MLAS_POOLING_KIND kind;
+        if (pool2d->GetType() == op::Pool2dType::kAveragePool2d) {
+            kind = MlasAveragePoolingIncludePad;
+        } else if (pool2d->GetType() == op::Pool2dType::kMaxPool2d) {
+            kind = MlasMaximumPooling;
+        } else {
+            return DAWN_INTERNAL_ERROR("Pool type is unsupported");
+        }
+        size_t batchCount = inputOperand->Shape()[0];
+        size_t inputChannels = inputOperand->Shape()[1];
+        std::vector<int64_t> inputShape = {inputOperand->Shape()[0], inputOperand->Shape()[1],
+                                           inputOperand->Shape()[2], inputOperand->Shape()[3]};
+        int32_t inputHeight = inputOperand->Shape()[2];
+        int32_t inputWidth = inputOperand->Shape()[3];
+        bool globalPooling = options->windowDimensions == nullptr;
+        std::vector<int64_t> kernelShape = {
+            options->windowDimensions ? options->windowDimensions[0] : inputOperand->Shape()[2],
+            options->windowDimensions ? options->windowDimensions[1] : inputOperand->Shape()[3]};
+        std::vector<int64_t> dilationShape = {options->dilations[0], options->dilations[1]};
+        int32_t paddingBeginningHeight = options->padding[0],
+                paddingEndingHeight = options->padding[1],
+                paddingBeginningWidth = options->padding[2],
+                paddingEndingWidth = options->padding[3];
+        if (options->autoPad != ml::AutoPad::Explicit) {
+            utils::ComputeImplicitPaddingForAutoPad(
+                options->autoPad, options->dilations[0], inputHeight, kernelShape[0],
+                options->strides[0], paddingBeginningHeight, paddingEndingHeight);
+            utils::ComputeImplicitPaddingForAutoPad(options->autoPad, options->dilations[1],
+                                                    inputWidth, kernelShape[1], options->strides[1],
+                                                    paddingBeginningWidth, paddingEndingWidth);
+        }
+        std::vector<int64_t> padding = {paddingBeginningHeight, paddingEndingHeight,
+                                        paddingBeginningWidth, paddingEndingWidth};
+        std::vector<int64_t> strideShape = {options->strides[0], options->strides[1]};
+
+        bool reorderInput = true;
+        // The current implementation of ReorderInput requires the channel count to be
+        // aligned to this value.
+        constexpr int64_t channelAlignment = 4;
+        const int64_t nchwcChannels = (inputChannels + nchwcBlockSize - 1) & ~(nchwcBlockSize - 1);
+
+        if (static_cast<size_t>(inputChannels) < nchwcBlockSize) {
+            // Use NCHW input buffer directly.
+            reorderInput = false;
+        } else {
+            if ((inputChannels % channelAlignment) != 0) {
+                nchwcPool = false;
+            }
+        }
+
+        if (!nchwcPool) {
+            return DAWN_INTERNAL_ERROR("Only support nchwc pool");
+        }
+
+        DAWN_ASSERT(mMemoryMap.find(inputOperand) != mMemoryMap.end());
+        Ref<Memory> inputMemory = mMemoryMap.at(inputOperand);
+        if (nchwcPool && reorderInput) {
+            if (!inputMemory->IsBlockedLayout()) {
+                Ref<Memory> reorderInputMemory = inputMemory;
+                std::vector<int32_t> reorderedOutputShape = {static_cast<int32_t>(batchCount),
+                                                             static_cast<int32_t>(nchwcChannels),
+                                                             inputHeight, inputWidth};
+                Ref<Memory> reorderOutputMemory =
+                    AcquireRef(new Memory(inputOperand->Type(), reorderedOutputShape, true));
+                if (!reorderOutputMemory->Allocate()) {
+                    return DAWN_INTERNAL_ERROR("Failed to allocate reorder output memory.");
+                }
+                size_t inputSize = inputHeight * inputWidth;
+                mKernels.push_back(AcquireRef(new ReorderInput(
+                    reorderInputMemory, reorderOutputMemory, inputChannels, inputSize)));
+                inputMemory = reorderOutputMemory;
+                inputShape[1] = nchwcChannels;
+            } else {
+                inputShape[1] = inputMemory->GetDimensions()[1];
+            }
+        }
+
+        const OperandBase* outputOperand = pool2d->PrimaryOutput();
+        std::vector<int64_t> outputShape = {outputOperand->Shape()[0], nchwcChannels,
+                                            outputOperand->Shape()[2], outputOperand->Shape()[3]};
+        Ref<Memory> outputMemory;
+        std::vector<int32_t> nchwcOutputShape = {
+            outputOperand->Shape()[0], inputMemory->GetDimensions()[1], outputOperand->Shape()[2],
+            outputOperand->Shape()[3]};
+        outputMemory = AcquireRef(new Memory(outputOperand->Type(), nchwcOutputShape, true));
+        if (!outputMemory->Allocate()) {
+            return DAWN_INTERNAL_ERROR("Failed to allocate output memory");
+        }
+        mMemoryMap.insert(std::make_pair(outputOperand, outputMemory));
+        Ref<Pool2d> kernel =
+            AcquireRef(new Pool2d(kind, globalPooling, inputMemory, outputMemory, inputShape,
+                                  kernelShape, dilationShape, padding, strideShape, outputShape));
+#if (VERBOSE)
+        dawn::InfoLog() << "Add pool2d " << pool2d << " kernel " << kernel.Get();
+#endif
+        mKernels.push_back(kernel);
+        return {};
+    }
+
+    MaybeError Graph::AddUnary(const op::Unary* unary) {
+        op::UnaryOpType opType = unary->GetType();
+        if (opType == op::UnaryOpType::kExp || opType == op::UnaryOpType::kHardSwish ||
+            opType == op::UnaryOpType::kLeakyRelu || opType == op::UnaryOpType::kRelu ||
+            opType == op::UnaryOpType::kSigmoid || opType == op::UnaryOpType::kSoftmax ||
+            opType == op::UnaryOpType::kTanh) {
+            const OperandBase* inputOperand = unary->Inputs()[0].Get();
+            if (inputOperand->Type() != ml::OperandType::Float32) {
+                return DAWN_INTERNAL_ERROR("Only support float32");
+            }
+            DAWN_ASSERT(mMemoryMap.find(inputOperand) != mMemoryMap.end());
+            Ref<Memory> inputMemory = mMemoryMap.at(inputOperand);
+            const OperandBase* outputOperand = unary->PrimaryOutput();
+            Ref<Memory> outputMemory =
+                AcquireRef(new Memory(outputOperand->Type(), outputOperand->Shape()));
+            if (!outputMemory->Allocate()) {
+                return DAWN_INTERNAL_ERROR("Failed to allocate output memory");
+            }
+            mMemoryMap.insert(std::make_pair(outputOperand, outputMemory));
+            std::vector<int32_t> dimensions = inputOperand->Shape();
+            size_t elementNum = std::accumulate(dimensions.begin(), dimensions.end(), (size_t)1,
+                                                std::multiplies<size_t>{});
+            MLAS_ACTIVATION activation;
+            if (opType == op::UnaryOpType::kRelu) {
+                activation.ActivationKind = MlasReluActivation;
+            } else if (opType == op::UnaryOpType::kHardSwish) {
+                activation.ActivationKind = MlasHardSigmoidActivation;
+                activation.Parameters.HardSigmoid.alpha = 1.0 / 6.0;
+                activation.Parameters.HardSigmoid.beta = 0.5;
+            } else if (opType == op::UnaryOpType::kLeakyRelu) {
+                activation.ActivationKind = MlasLeakyReluActivation;
+                activation.Parameters.LeakyRelu.alpha =
+                    reinterpret_cast<const op::LeakyRelu*>(unary)->GetAlpha();
+            }
+            mKernels.push_back(
+                AcquireRef(new Unary(opType, inputMemory, outputMemory, elementNum, activation)));
+        } else {
+            return DAWN_UNIMPLEMENTED_ERROR("Unsupported unary op");
+        }
+        return {};
+    }
+
+    MaybeError Graph::Finish() {
+        return {};
+    }
+
+    MaybeError Graph::CompileImpl() {
+        return {};
+    }
+
+    MLComputeGraphStatus Graph::ComputeImpl(NamedInputsBase* inputs, NamedOutputsBase* outputs) {
+        for (auto& input : inputs->GetRecords()) {
+            Ref<Memory> inputMemory = mInputs.at(input.first);
+            if (inputMemory->GetByteLength() < input.second->resource.byteLength) {
+                dawn::ErrorLog() << "The size of input memory is less than input buffer.";
+                return MLComputeGraphStatus_Error;
+            }
+            memcpy(inputMemory->GetBuffer(),
+                   static_cast<int8_t*>(input.second->resource.buffer) +
+                       input.second->resource.byteOffset,
+                   input.second->resource.byteLength);
+        }
+
+        for (auto& kernel : mKernels) {
+            kernel->Compute(reinterpret_cast<Context*>(GetContext())->GetThreadPool());
+        }
+
+        std::vector<std::string> outputNames;
+        for (auto& output : outputs->GetRecords()) {
+            outputNames.push_back(output.first);
+        }
+
+        for (size_t i = 0; i < outputNames.size(); ++i) {
+            std::string outputName = outputNames[i];
+            Ref<Memory> outputMemory = mOutputs.at(outputName);
+            const ArrayBufferView* output = outputs->GetRecords().at(outputName);
+            if (output->byteLength < outputMemory->GetByteLength()) {
+                dawn::ErrorLog() << "The size of output buffer is less than output memory.";
+                return MLComputeGraphStatus_Error;
+            }
+            memcpy(static_cast<int8_t*>(output->buffer) + output->byteOffset,
+                   outputMemory->GetBuffer(), output->byteLength);
+        }
+        return MLComputeGraphStatus_Success;
+    }
+
+}}  // namespace webnn_native::mlas

--- a/src/webnn_native/mlas/GraphMLAS.cpp
+++ b/src/webnn_native/mlas/GraphMLAS.cpp
@@ -40,7 +40,9 @@ namespace webnn_native { namespace mlas {
 #elif defined(_LIBCPP_SGX_CONFIG)
         p = memalign(alignment, size);
 #else
-        posix_memalign(&p, alignment, size);
+        if (posix_memalign(&p, alignment, size) != 0) {
+            return nullptr;
+        }
 #endif
         return p;
     }

--- a/src/webnn_native/mlas/GraphMLAS.h
+++ b/src/webnn_native/mlas/GraphMLAS.h
@@ -1,0 +1,70 @@
+// Copyright 2021 The WebNN-native Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef WEBNN_NATIVE_MLAS_GRAPH_MLAS_H_
+#define WEBNN_NATIVE_MLAS_GRAPH_MLAS_H_
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "webnn_native/Graph.h"
+#include "webnn_native/Operand.h"
+#include "webnn_native/mlas/ContextMLAS.h"
+#include "webnn_native/ops/Binary.h"
+#include "webnn_native/ops/Clamp.h"
+#include "webnn_native/ops/Constant.h"
+#include "webnn_native/ops/Conv2d.h"
+#include "webnn_native/ops/Input.h"
+#include "webnn_native/ops/LeakyRelu.h"
+#include "webnn_native/ops/Pool2d.h"
+#include "webnn_native/ops/Reshape.h"
+#include "webnn_native/ops/Transpose.h"
+#include "webnn_native/ops/Unary.h"
+
+namespace webnn_native { namespace mlas {
+
+    class Memory;
+    class Kernel;
+    class Conv2d;
+
+    class Graph : public GraphBase {
+      public:
+        explicit Graph(Context* context);
+        ~Graph() override;
+
+        virtual MaybeError AddConstant(const op::Constant* constant) override;
+        virtual MaybeError AddInput(const op::Input* input) override;
+        virtual MaybeError AddOutput(const std::string& name, const OperandBase* output) override;
+        virtual MaybeError AddBinary(const op::Binary* binary) override;
+        virtual MaybeError AddClamp(const op::Clamp* clamp) override;
+        virtual MaybeError AddConv2d(const op::Conv2d* conv2d) override;
+        virtual MaybeError AddPool2d(const op::Pool2d* pool2d) override;
+        virtual MaybeError AddUnary(const op::Unary* unary) override;
+        virtual MaybeError Finish() override;
+
+      private:
+        MaybeError CompileImpl() override;
+        MLComputeGraphStatus ComputeImpl(NamedInputsBase* inputs,
+                                         NamedOutputsBase* outputs) override;
+
+        std::unordered_map<std::string, Ref<Memory>> mInputs;
+        std::unordered_map<std::string, Ref<Memory>> mOutputs;
+        std::unordered_map<const OperandBase*, Ref<Memory>> mMemoryMap;
+        std::unordered_map<const OperatorBase*, Ref<Conv2d>> mConv2dKernels;
+        std::vector<Ref<Kernel>> mKernels;
+    };
+
+}}  // namespace webnn_native::mlas
+
+#endif  // WEBNN_NATIVE_MLAS_GRAPH_MLAS_H_


### PR DESCRIPTION
Support 11 ops including:
 - conv2d (only nchw)
 - pool2d (only nchw, average and max)
 - add (only fused into conv2d)
 - activations: clamp, relu, leakyRelu, sigmoid, exp, hardswish
 - softmax

Depends on mlas of third_party/onnxruntime as one of DEPS.

fix #180 