### PR TITLE
Fix GN generation failure when building WebNN's common target from \\third_party.

### DIFF
--- a/src/common/BUILD.gn
+++ b/src/common/BUILD.gn
@@ -85,7 +85,10 @@ config("dawn_internal") {
 
   # Only internal Dawn targets can use this config, this means only targets in
   # this BUILD.gn file and related subdirs.
-  visibility = [ "../*" ]
+  visibility = [
+    "../*",
+    "../../examples/*",
+  ]
 
   cflags = []
 


### PR DESCRIPTION
WebNN's dawn_internal GN target was incorrectly scoped to to src/* which forbids examples/* targets from depending on it.