### PR TITLE
Remove -Wreturn-std-move-in-c++11

### DIFF
--- a/src/common/BUILD.gn
+++ b/src/common/BUILD.gn
@@ -105,7 +105,6 @@ config("dawn_internal") {
       "-Wnon-c-typedef-for-linkage",
       "-Wpessimizing-move",
       "-Wrange-loop-analysis",
-      "-Wreturn-std-move-in-c++11",
       "-Wshadow-field",
       "-Wstrict-prototypes",
       "-Wtautological-unsigned-zero-compare",


### PR DESCRIPTION
Clang has removed this flag and is no longer an option.