### PR TITLE
Fix the issue of no space in CI

### DIFF
--- a/.github/workflows/build_test_dml.yml
+++ b/.github/workflows/build_test_dml.yml
@@ -36,6 +36,7 @@ jobs:
       shell: pwsh
       run: |
         cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync code for main branch
@@ -81,6 +82,7 @@ jobs:
       shell: pwsh
       run: |
         cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code

--- a/.github/workflows/build_test_dml.yml
+++ b/.github/workflows/build_test_dml.yml
@@ -32,6 +32,12 @@ jobs:
         path: baseline
         fetch-depth: 0
 
+    - name: Update DEPS for main branch
+      shell: pwsh
+      run: |
+        cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
+
     - name: Sync code for main branch
       shell: cmd
       run: |
@@ -70,6 +76,12 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      shell: pwsh
+      run: |
+        cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code
       shell: cmd

--- a/.github/workflows/build_test_node_dml.yml
+++ b/.github/workflows/build_test_node_dml.yml
@@ -36,6 +36,12 @@ jobs:
         path: baseline
         fetch-depth: 0
 
+    - name: Update DEPS for main branch
+      shell: pwsh
+      run: |
+        cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
+
     - name: Sync code for main branch
       shell: cmd
       run: |
@@ -93,6 +99,12 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      shell: pwsh
+      run: |
+        cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code
       shell: cmd

--- a/.github/workflows/build_test_node_dml.yml
+++ b/.github/workflows/build_test_node_dml.yml
@@ -94,6 +94,7 @@ jobs:
         echo "Baseline node test result:"
         type baseline\node\result.xml
         copy baseline\node\result.xml ${{ github.workspace }}\..\baseline.xml
+        rmdir /s /q baseline
 
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build_test_node_dml.yml
+++ b/.github/workflows/build_test_node_dml.yml
@@ -40,6 +40,7 @@ jobs:
       shell: pwsh
       run: |
         cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync code for main branch
@@ -105,6 +106,7 @@ jobs:
       shell: pwsh
       run: |
         cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code

--- a/.github/workflows/build_test_node_openvino_linux.yml
+++ b/.github/workflows/build_test_node_openvino_linux.yml
@@ -86,6 +86,7 @@ jobs:
         echo "Baseline node test result:"
         cat baseline/node/result.xml
         cp baseline/node/result.xml ${{ github.workspace }}/../baseline.xml
+        rm -rf baseline
 
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build_test_node_openvino_linux.yml
+++ b/.github/workflows/build_test_node_openvino_linux.yml
@@ -38,6 +38,11 @@ jobs:
         path: baseline
         fetch-depth: 0
 
+    - name: Update DEPS for main branch
+      run: |
+        cd baseline
+        sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
+
     - name: Sync code for main branch
       run: |
         export PATH=$PWD/../depot_tools:$PATH
@@ -86,6 +91,11 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      run: |
+        cd update
+        sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync latest code
       run: |

--- a/.github/workflows/build_test_node_openvino_linux.yml
+++ b/.github/workflows/build_test_node_openvino_linux.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Update DEPS for main branch
       run: |
         cd baseline
+        sed -i "s/'checkout_onnxruntime':\ True/'checkout_onnxruntime':\ False/" DEPS
         sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync code for main branch
@@ -96,6 +97,7 @@ jobs:
     - name: Update DEPS for update branch
       run: |
         cd update
+        sed -i "s/'checkout_onnxruntime':\ True/'checkout_onnxruntime':\ False/" DEPS
         sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync latest code

--- a/.github/workflows/build_test_node_openvino_windows.yml
+++ b/.github/workflows/build_test_node_openvino_windows.yml
@@ -58,6 +58,7 @@ jobs:
       shell: pwsh
       run: |
         cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Generate project for main branch
@@ -112,6 +113,7 @@ jobs:
       shell: pwsh
       run: |
         cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code

--- a/.github/workflows/build_test_node_openvino_windows.yml
+++ b/.github/workflows/build_test_node_openvino_windows.yml
@@ -101,6 +101,7 @@ jobs:
         echo "Baseline node test result:"
         type baseline\node\result.xml
         copy baseline\node\result.xml ${{ github.workspace }}\..\baseline.xml
+        rmdir /s /q baseline
 
     - uses: actions/checkout@v2
       with:

--- a/.github/workflows/build_test_node_openvino_windows.yml
+++ b/.github/workflows/build_test_node_openvino_windows.yml
@@ -54,6 +54,12 @@ jobs:
         copy scripts\standalone.gclient .gclient
         gclient sync
 
+    - name: Update DEPS for main branch
+      shell: pwsh
+      run: |
+        cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
+
     - name: Generate project for main branch
       shell: cmd
       run: |
@@ -100,6 +106,12 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      shell: pwsh
+      run: |
+        cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code
       shell: cmd

--- a/.github/workflows/build_test_null.yml
+++ b/.github/workflows/build_test_null.yml
@@ -36,6 +36,7 @@ jobs:
       shell: pwsh
       run: |
         cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_polyfill': True", "'checkout_polyfill': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
@@ -82,6 +83,7 @@ jobs:
       shell: pwsh
       run: |
         cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_polyfill': True", "'checkout_polyfill': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 

--- a/.github/workflows/build_test_null.yml
+++ b/.github/workflows/build_test_null.yml
@@ -32,6 +32,13 @@ jobs:
         path: baseline
         fetch-depth: 0
 
+    - name: Update DEPS for main branch
+      shell: pwsh
+      run: |
+        cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_polyfill': True", "'checkout_polyfill': False" | Set-Content -path .\DEPS
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
+
     - name: Sync code for main branch
       shell: cmd
       run: |
@@ -70,6 +77,13 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      shell: pwsh
+      run: |
+        cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_polyfill': True", "'checkout_polyfill': False" | Set-Content -path .\DEPS
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code
       shell: cmd

--- a/.github/workflows/build_test_onednn_linux.yml
+++ b/.github/workflows/build_test_onednn_linux.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Update DEPS for main branch
       run: |
         cd baseline
+        sed -i "s/'checkout_onnxruntime':\ True/'checkout_onnxruntime':\ False/" DEPS
         sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync code for main branch
@@ -78,6 +79,7 @@ jobs:
     - name: Update DEPS for update branch
       run: |
         cd update
+        sed -i "s/'checkout_onnxruntime':\ True/'checkout_onnxruntime':\ False/" DEPS
         sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync latest code

--- a/.github/workflows/build_test_onednn_linux.yml
+++ b/.github/workflows/build_test_onednn_linux.yml
@@ -30,6 +30,11 @@ jobs:
         path: baseline
         fetch-depth: 0
 
+    - name: Update DEPS for main branch
+      run: |
+        cd baseline
+        sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
+
     - name: Sync code for main branch
       run: |
         export PATH=$PWD/../depot_tools:$PATH
@@ -69,6 +74,11 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      run: |
+        cd update
+        sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync latest code
       run: |

--- a/.github/workflows/build_test_onednn_windows.yml
+++ b/.github/workflows/build_test_onednn_windows.yml
@@ -31,6 +31,12 @@ jobs:
         path: baseline
         fetch-depth: 0
 
+    - name: Update DEPS for main branch
+      shell: pwsh
+      run: |
+        cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
+
     - name: Sync code for main branch
       shell: cmd
       run: |
@@ -77,6 +83,12 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      shell: pwsh
+      run: |
+        cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code
       shell: cmd

--- a/.github/workflows/build_test_onednn_windows.yml
+++ b/.github/workflows/build_test_onednn_windows.yml
@@ -35,6 +35,7 @@ jobs:
       shell: pwsh
       run: |
         cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync code for main branch
@@ -88,6 +89,7 @@ jobs:
       shell: pwsh
       run: |
         cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code

--- a/.github/workflows/build_test_openvino_linux.yml
+++ b/.github/workflows/build_test_openvino_linux.yml
@@ -38,6 +38,11 @@ jobs:
         path: baseline
         fetch-depth: 0
 
+    - name: Update DEPS for main branch
+      run: |
+        cd baseline
+        sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
+
     - name: Sync code for main branch
       run: |
         export PATH=$PWD/../depot_tools:$PATH
@@ -70,6 +75,11 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      run: |
+        cd update
+        sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync latest code
       run: |

--- a/.github/workflows/build_test_openvino_linux.yml
+++ b/.github/workflows/build_test_openvino_linux.yml
@@ -41,6 +41,7 @@ jobs:
     - name: Update DEPS for main branch
       run: |
         cd baseline
+        sed -i "s/'checkout_onnxruntime':\ True/'checkout_onnxruntime':\ False/" DEPS
         sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync code for main branch
@@ -79,6 +80,7 @@ jobs:
     - name: Update DEPS for update branch
       run: |
         cd update
+        sed -i "s/'checkout_onnxruntime':\ True/'checkout_onnxruntime':\ False/" DEPS
         sed -i "s/'checkout_samples':\ True/'checkout_samples':\ False/" DEPS
 
     - name: Sync latest code

--- a/.github/workflows/build_test_openvino_windows.yml
+++ b/.github/workflows/build_test_openvino_windows.yml
@@ -45,6 +45,12 @@ jobs:
         path: baseline
         fetch-depth: 0
 
+    - name: Update DEPS for main branch
+      shell: pwsh
+      run: |
+        cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
+
     - name: Sync code for main branch
       shell: cmd
       run: |
@@ -80,6 +86,12 @@ jobs:
       with:
         path: update
         fetch-depth: 0
+
+    - name: Update DEPS for update branch
+      shell: pwsh
+      run: |
+        cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code
       shell: cmd

--- a/.github/workflows/build_test_openvino_windows.yml
+++ b/.github/workflows/build_test_openvino_windows.yml
@@ -49,6 +49,7 @@ jobs:
       shell: pwsh
       run: |
         cd baseline
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync code for main branch
@@ -91,6 +92,7 @@ jobs:
       shell: pwsh
       run: |
         cd update
+        (Get-Content -path .\DEPS -Raw) -replace "'checkout_onnxruntime': True", "'checkout_onnxruntime': False" | Set-Content -path .\DEPS
         (Get-Content -path .\DEPS -Raw) -replace "'checkout_samples': True", "'checkout_samples': False" | Set-Content -path .\DEPS
 
     - name: Sync latest code

--- a/DEPS
+++ b/DEPS
@@ -9,21 +9,27 @@ vars = {
 
   'dawn_standalone': True,
   'checkout_onnxruntime': False,
+  'checkout_polyfill': True,
+  'checkout_samples': True,
 }
 
 deps = {
   # Dependencies required for tests.
   'node/third_party/webnn-polyfill': {
-    'url': '{github_git}/webmachinelearning/webnn-polyfill.git@9ef11ab490be1275df801a43a7b81977b6966560'
+    'url': '{github_git}/webmachinelearning/webnn-polyfill.git@9ef11ab490be1275df801a43a7b81977b6966560',
+    'condition': 'checkout_polyfill',
   },
   'node/third_party/webnn-polyfill/test-data': {
-    'url': '{github_git}/webmachinelearning/test-data.git@b6f1565fefc103705a6ff580067eae7bb9d3b351'
+    'url': '{github_git}/webmachinelearning/test-data.git@b6f1565fefc103705a6ff580067eae7bb9d3b351',
+    'condition': 'checkout_polyfill',
   },
   'node/third_party/webnn-samples': {
-    'url': '{github_git}/webmachinelearning/webnn-samples.git@d358fe623be5236736ebc2d896cfbba2af4fd348'
+    'url': '{github_git}/webmachinelearning/webnn-samples.git@d358fe623be5236736ebc2d896cfbba2af4fd348',
+    'condition': 'checkout_samples'
   },
   'node/third_party/webnn-samples/test-data': {
-    'url': '{github_git}/webmachinelearning/test-data.git@b6f1565fefc103705a6ff580067eae7bb9d3b351'
+    'url': '{github_git}/webmachinelearning/test-data.git@b6f1565fefc103705a6ff580067eae7bb9d3b351',
+    'condition': 'checkout_samples'
   },
   'third_party/stb': {
     'url': '{github_git}/nothings/stb@b42009b3b9d4ca35bc703f5310eedc74f584be58'

--- a/DEPS
+++ b/DEPS
@@ -8,7 +8,7 @@ vars = {
   'github_git': 'https://github.com',
 
   'dawn_standalone': True,
-  'checkout_onnxruntime': False,
+  'checkout_onnxruntime': True,
   'checkout_polyfill': True,
   'checkout_samples': True,
 }

--- a/README.md
+++ b/README.md
@@ -60,9 +60,6 @@ Get the source code as follows:
 > gclient sync
 ```
 
-**Notes**
- * To build with MLAS backend, please set `'checkout_onnxruntime': True` in DEPS.
-
 ### Setting up the build
 
 Generate build files using `gn args out/Debug` or `gn args out/Release`.


### PR DESCRIPTION

This PR is

1. to introduce two conditions variables `checkout_polyfill` and `checkout_samples`, those **webnn-polyfill**(608M), **webnn-samples**(700M) and **test-data**(1.2G) dependencies repos would be checkout by default
2. to enable checkout **onnxruntime**(858M) dependency repo by default

Following table shows the checkout status in CI:

|CI \ Repo|webnn-polyfill (608M) + test-data(1.2G)|webnn-samples(700M) + test-data(1.2G)|onnxruntime (858M)|
|----|----|----|----|
|CI for null backend|NO|NO|NO|
|CI for DML/OpenVINO/oneDNN native backends|YES(1)|NO|NO|
|CI for WebNN-native Binding for node.js|YES|NO|NO|
|CI for MLAS backend _(TODO)_|YES(1)|NO|YES|

Note:
(1) Actually in CI for native backends, only test-data repo is required to checkout for testing End2End tests(model tests).

@fujunwei @huningxin PTAL, thanks.