### PR TITLE
Fix Graph::AddGemm from variable shadowing.

### DIFF
--- a/src/webnn_native/dml/GraphDML.cpp
+++ b/src/webnn_native/dml/GraphDML.cpp
@@ -1522,7 +1522,7 @@ namespace webnn_native { namespace dml {
             // The shape of c tensor is 2D definited in WebNN Spec, but DML only support 4D,
             // so expand dimensions to 4D.
             DAWN_ASSERT(cDims.size() == 2);
-            auto expandDims = ExpandDimensions(cDims, 4);
+            expandDims = ExpandDimensions(cDims, 4);
             auto expandStrides = CalculateBroadcastStrides(expandDims, broadcast);
             c = ::dml::Reinterpret(c->Impl(), expandDims, expandStrides);
         }


### PR DESCRIPTION

Latest Clang does not allow re-declaring a local variable.
This fix simply removes the local variable declaration.

Fix #196