### PR TITLE
Roll third_party/gpgmm/ 7c81fae56..c52956998 (157 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -47,7 +47,7 @@ deps = {
   },
   # GPGMM support for fast DML allocation and residency management.
   'third_party/gpgmm': {
-    'url': '{github_git}/intel/gpgmm.git@7c81fae56e30c60030cb0a2c53310723e5c085d6',
+    'url': '{github_git}/intel/gpgmm.git@c52956998962b6481d99739eaf077997ef89abe2',
     'condition': 'checkout_win',
   },
   'third_party/oneDNN': {


### PR DESCRIPTION
New allocation system. GPGMM is now O(1) and O(gpuPageSize) vs WebGPU/Dawn's O(Log2) and O(resourceHeapSize) for time and space complexity, respectively.