### PR TITLE
Support selecting iGPU/dGPU on DML backend

### DIFF
--- a/examples/MobileNetV2/Main.cpp
+++ b/examples/MobileNetV2/Main.cpp
@@ -29,7 +29,8 @@ int main(int argc, const char* argv[]) {
     }
 
     // Create a graph with weights and biases from .npy files.
-    const ml::ContextOptions options = utils::CreateContextOptions(mobilevetv2.mDevice);
+    const ml::ContextOptions options =
+        utils::CreateContextOptions(mobilevetv2.mDevicePreference, mobilevetv2.mPowerPreference);
     ml::Context context = CreateCppContext(&options);
     context.SetUncapturedErrorCallback(
         [](MLErrorType type, char const* message, void* userData) {

--- a/examples/ResNet/Main.cpp
+++ b/examples/ResNet/Main.cpp
@@ -29,7 +29,8 @@ int main(int argc, const char* argv[]) {
     }
 
     // Create a graph with weights and biases from .npy files.
-    const ml::ContextOptions options = utils::CreateContextOptions(resnet.mDevice);
+    const ml::ContextOptions options =
+        utils::CreateContextOptions(resnet.mDevicePreference, resnet.mPowerPreference);
     ml::Context context = CreateCppContext(&options);
     context.SetUncapturedErrorCallback(
         [](MLErrorType type, char const* message, void* userData) {

--- a/examples/SampleUtils.h
+++ b/examples/SampleUtils.h
@@ -48,7 +48,8 @@ class ExampleBase {
     std::vector<float> mStd = {1, 1, 1};   // Variance values of pixels on channels.
     std::string mChannelScheme = "RGB";
     std::vector<int32_t> mOutputShape;
-    std::string mDevice = "default";
+    std::string mDevicePreference = "default";
+    std::string mPowerPreference = "default";
     bool mFused = true;
 };
 
@@ -328,7 +329,8 @@ namespace utils {
     void PrintExexutionTime(
         std::vector<std::chrono::duration<double, std::milli>> executionTimeVector);
 
-    const ml::ContextOptions CreateContextOptions(const std::string& device = "default");
+    const ml::ContextOptions CreateContextOptions(const std::string& devicePreference = "default",
+                                                  const std::string& powerPreference = "default");
 }  // namespace utils
 
 #endif  // WEBNN_NATIVE_EXAMPLES_SAMPLE_UTILS_H_

--- a/examples/SqueezeNet/Main.cpp
+++ b/examples/SqueezeNet/Main.cpp
@@ -29,7 +29,8 @@ int main(int argc, const char* argv[]) {
     }
 
     // Create a graph with weights and biases from .npy files.
-    const ml::ContextOptions options = utils::CreateContextOptions(squeezenet.mDevice);
+    const ml::ContextOptions options =
+        utils::CreateContextOptions(squeezenet.mDevicePreference, squeezenet.mPowerPreference);
     ml::Context context = CreateCppContext(&options);
     context.SetUncapturedErrorCallback(
         [](MLErrorType type, char const* message, void* userData) {

--- a/src/tests/End2EndTestsMain.cpp
+++ b/src/tests/End2EndTestsMain.cpp
@@ -16,13 +16,17 @@
 #include "tests/WebnnTest.h"
 
 int main(int argc, char** argv) {
-    std::string device = "default";
+    std::string devicePreference = "default", powerPreference = "default";
     for (int i = 1; i < argc; ++i) {
         if (strcmp("-d", argv[i]) == 0 && i + 1 < argc) {
-            device = argv[i + 1];
+            devicePreference = argv[i + 1];
+        }
+        if (strcmp("-p", argv[i]) == 0 && i + 1 < argc) {
+            powerPreference = argv[i + 1];
         }
     }
-    const ml::ContextOptions options = utils::CreateContextOptions(device);
+    const ml::ContextOptions options =
+        utils::CreateContextOptions(devicePreference, powerPreference);
     InitWebnnEnd2EndTestEnvironment(&options);
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/src/webnn_native/dml/GraphDML.cpp
+++ b/src/webnn_native/dml/GraphDML.cpp
@@ -461,10 +461,23 @@ namespace webnn_native { namespace dml {
     Graph::Graph(Context* context) : GraphBase(context) {
         ml::DevicePreference devicePreference = GetContext()->GetContextOptions().devicePreference;
         bool useGpu = devicePreference == ml::DevicePreference::Cpu ? false : true;
+
+        ml::PowerPreference powerPreference = GetContext()->GetContextOptions().powerPreference;
+        DXGI_GPU_PREFERENCE gpuPreference;
+        switch (powerPreference) {
+            case ml::PowerPreference::High_performance:
+                gpuPreference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE;
+                break;
+            case ml::PowerPreference::Low_power:
+                gpuPreference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_MINIMUM_POWER;
+                break;
+            default:
+                gpuPreference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED;
+        }
 #if defined(_DEBUG)
-        mDevice.reset(new ::pydml::Device(useGpu, true));
+        mDevice.reset(new ::pydml::Device(useGpu, true, gpuPreference));
 #else
-        mDevice.reset(new ::pydml::Device(useGpu, false));
+        mDevice.reset(new ::pydml::Device(useGpu, false, gpuPreference));
 #endif
         mDevice->Init();
         mGraph.reset(new ::dml::Graph(mDevice->GetDevice()));

--- a/src/webnn_native/dml/deps/src/device.cpp
+++ b/src/webnn_native/dml/deps/src/device.cpp
@@ -19,7 +19,20 @@ SVDescriptorHeap::SVDescriptorHeap(
         m_Heap(std::move(heap)) {
 }
 
-Device::Device(bool useGpu, bool useDebugLayer) : m_useGpu(useGpu), m_useDebugLayer(useDebugLayer) {}
+Device::Device(bool useGpu, bool useDebugLayer, DXGI_GPU_PREFERENCE gpuPreference) : m_useGpu(useGpu), m_useDebugLayer(useDebugLayer), m_gpuPreference(gpuPreference) {}
+
+// An adapter called the "Microsoft Basic Render Driver" is always present. This adapter is a render-only device that has no display outputs.
+HRESULT IsWarpAdapter(IDXGIAdapter1* pAdapter, bool* isWarpAdapter) {
+    DXGI_ADAPTER_DESC1 pDesc;
+    ReturnIfFailed(pAdapter->GetDesc1(&pDesc));
+    // see here for documentation on filtering WARP adapter:
+    // https://docs.microsoft.com/en-us/windows/desktop/direct3ddxgi/d3d10-graphics-programming-guide-dxgi#new-info-about-enumerating-adapters-for-windows-8
+    auto isBasicRenderDriverVendorId = pDesc.VendorId == 0x1414;
+    auto isBasicRenderDriverDeviceId = pDesc.DeviceId == 0x8c;
+    auto isSoftwareAdapter = pDesc.Flags == DXGI_ADAPTER_FLAG_SOFTWARE;
+    *isWarpAdapter = isSoftwareAdapter || (isBasicRenderDriverVendorId && isBasicRenderDriverDeviceId);
+    return S_OK;
+}
 
 HRESULT Device::Init()
 {
@@ -35,10 +48,27 @@ HRESULT Device::Init()
             debugController->EnableDebugLayer();
         }
     }
-    Microsoft::WRL::ComPtr<IDXGIAdapter> dxgiAdapter;
-    if (    !m_useGpu 
-        ||  FAILED(D3D12CreateDevice(nullptr, D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_d3d12Device))))
+
+    Microsoft::WRL::ComPtr<IDXGIAdapter1> dxgiAdapter;
+    if(m_useGpu)
     {
+        ComPtr<IDXGIFactory6> spFactory;
+        ReturnIfFailed(CreateDXGIFactory1(IID_PPV_ARGS(&spFactory)));
+        UINT i =   0;
+        while ( spFactory->EnumAdapterByGpuPreference(i, m_gpuPreference, IID_PPV_ARGS(&dxgiAdapter))!= DXGI_ERROR_NOT_FOUND) {
+            bool isWarpAdapter = false;
+            ReturnIfFailed(IsWarpAdapter(dxgiAdapter.Get(), &isWarpAdapter));
+            if (!isWarpAdapter) {
+                break;
+            }
+            ++i;
+        }
+    }
+
+    if (    !m_useGpu 
+        ||  FAILED(D3D12CreateDevice(dxgiAdapter.Get(), D3D_FEATURE_LEVEL_11_0, IID_PPV_ARGS(&m_d3d12Device))))
+    {
+        //If a computer's display driver is not functioning or is disabled, the computer's primary (NULL) adapter might also be called "Microsoft Basic Render Driver."
         Microsoft::WRL::ComPtr<IDXGIFactory4> dxgiFactory;
         ReturnIfFailed(CreateDXGIFactory1(IID_PPV_ARGS(&dxgiFactory)));
         ReturnIfFailed(dxgiFactory->EnumWarpAdapter(IID_PPV_ARGS(&dxgiAdapter)));

--- a/src/webnn_native/dml/deps/src/device.h
+++ b/src/webnn_native/dml/deps/src/device.h
@@ -19,7 +19,7 @@ namespace pydml
     class Device
     {
     public:
-        explicit Device(bool useGpu = true, bool useDebugLayer = false);
+        explicit Device(bool useGpu = true, bool useDebugLayer = false, DXGI_GPU_PREFERENCE gpuPreference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED);
 
         HRESULT Init();
 
@@ -102,5 +102,6 @@ namespace pydml
         bool m_useCpuCustomHeapResources = false;
         bool m_useGpu = true;
         bool m_useDebugLayer = false;
+        DXGI_GPU_PREFERENCE m_gpuPreference;
     };
 }

--- a/src/webnn_native/dml/deps/src/precomp.h
+++ b/src/webnn_native/dml/deps/src/precomp.h
@@ -22,6 +22,7 @@
 
 // ToDo: dxgi isn't available in WSL.
 #include <dxgi1_5.h>
+#include <dxgi1_6.h>
 #include <dxgidebug.h>
 
 #include <initguid.h>


### PR DESCRIPTION
Enable setting power preference for selecting iGPU/dGPU on DML backend. Now you can choose iGpu/dGpu when running C++ examples and end2end tests under the webnn-native folder, for example:
iGpu: `out\Release\webnn_end2end_tests.exe --gtest_filter=*AddTests* -p low-power`
dGpu:` out\Release\webnn_end2end_tests.exe --gtest_filter=*AddTests* -p high-performance`


[Remarks](https://docs.microsoft.com/en-us/windows/win32/api/dxgi1_6/nf-dxgi1_6-idxgifactory6-enumadapterbygpupreference):
When DXGI_GPU_PREFERENCE_MINIMUM_POWER is specified for the GpuPreference parameter, the order of preference for the adapter returned in ppvAdapter will be:

1. iGPUs (integrated GPUs)
2. dGPUs (discrete GPUs)
3. xGPUs (external GPUs)

When DXGI_GPU_PREFERENCE_HIGH_PERFORMANCE is specified for the GpuPreference parameter, the order of preference for the adapter returned in ppvAdapter will be:

1. xGPUs
2. dGPUs
3. iGPUs

PTAL, thanks! @huningxin @fujunwei 