### PR TITLE
Enable DML leak detection.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -47,7 +47,7 @@ deps = {
   },
   # GPGMM support for fast DML allocation and residency management.
   'third_party/gpgmm': {
-    'url': '{github_git}/intel/gpgmm.git@c52956998962b6481d99739eaf077997ef89abe2',
+    'url': '{github_git}/intel/gpgmm.git@1e5ae00712c8f91e209864027818e26093df9f45',
     'condition': 'checkout_win',
   },
   'third_party/oneDNN': {

--- a/src/webnn_native/dml/deps/src/device.cpp
+++ b/src/webnn_native/dml/deps/src/device.cpp
@@ -112,6 +112,11 @@ HRESULT Device::Init()
     allocatorDesc.Device = m_d3d12Device;
     allocatorDesc.IsUMA = arch.UMA;
     allocatorDesc.ResourceHeapTier = options.ResourceHeapTier;
+
+    if (m_useDebugLayer){
+        allocatorDesc.Flags |= gpgmm::d3d12::ALLOCATOR_FLAGS::ALLOCATOR_CHECK_DEVICE_LEAKS;
+    }
+
     ReturnIfFailed(gpgmm::d3d12::ResourceAllocator::CreateAllocator(allocatorDesc, &m_resourceAllocator));
 
     m_residencyManager = m_resourceAllocator->GetResidencyManager();


### PR DESCRIPTION
GPGMM will ASSERT if device allocation leaks are present.

Roll third_party/gpgmm/ c52956998..1e5ae0071 (16 commits).