### PR TITLE
Roll third_party/gpgmm/ 1e5ae0071..c5cd36d84 (181 commits)

### DIFF
--- a/.github/workflows/build_test_dml.yml
+++ b/.github/workflows/build_test_dml.yml
@@ -54,7 +54,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd baseline
-        gn gen out\Release --args="webnn_enable_dml=true is_debug=false"
+        gn gen out\Release --args="webnn_enable_dml=true is_debug=false gpgmm_enable_device_checks=true"
 
     - name: Build for main branch
       shell: cmd
@@ -100,7 +100,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd update
-        gn gen out\Release --args="webnn_enable_dml=true webnn_enable_wire=true is_debug=false"
+        gn gen out\Release --args="webnn_enable_dml=true webnn_enable_wire=true is_debug=false gpgmm_enable_device_checks=true"
 
     - name: Build for update branch
       shell: cmd

--- a/.github/workflows/build_test_node_dml.yml
+++ b/.github/workflows/build_test_node_dml.yml
@@ -58,7 +58,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd baseline
-        gn gen out\Release --args="webnn_enable_dml=true is_debug=false"
+        gn gen out\Release --args="webnn_enable_dml=true is_debug=false gpgmm_enable_device_checks=true"
 
     - name: Build for main branch
       shell: cmd
@@ -124,7 +124,7 @@ jobs:
         set "PATH=%CD%\..\depot_tools;%PATH%"
         set "DEPOT_TOOLS_WIN_TOOLCHAIN=0"
         cd update
-        gn gen out\Release --args="webnn_enable_dml=true is_debug=false"
+        gn gen out\Release --args="webnn_enable_dml=true is_debug=false gpgmm_enable_device_checks=true"
 
     - name: Build for update branch
       shell: cmd

--- a/DEPS
+++ b/DEPS
@@ -55,7 +55,7 @@ deps = {
   },
   # GPGMM support for fast DML allocation and residency management.
   'third_party/gpgmm': {
-    'url': '{github_git}/intel/gpgmm.git@1e5ae00712c8f91e209864027818e26093df9f45',
+    'url': '{github_git}/intel/gpgmm.git@c5cd36d842b7767590ba334f355c45a3eb264d2d',
     'condition': 'checkout_win',
   },
   'third_party/oneDNN': {

--- a/src/webnn_native/dml/deps/src/device.cpp
+++ b/src/webnn_native/dml/deps/src/device.cpp
@@ -112,14 +112,7 @@ HRESULT Device::Init()
     allocatorDesc.Device = m_d3d12Device;
     allocatorDesc.IsUMA = arch.UMA;
     allocatorDesc.ResourceHeapTier = options.ResourceHeapTier;
-
-    if (m_useDebugLayer){
-        allocatorDesc.Flags |= gpgmm::d3d12::ALLOCATOR_FLAGS::ALLOCATOR_CHECK_DEVICE_LEAKS;
-    }
-
-    ReturnIfFailed(gpgmm::d3d12::ResourceAllocator::CreateAllocator(allocatorDesc, &m_resourceAllocator));
-
-    m_residencyManager = m_resourceAllocator->GetResidencyManager();
+    ReturnIfFailed(gpgmm::d3d12::ResourceAllocator::CreateAllocator(allocatorDesc, &m_resourceAllocator, &m_residencyManager));
 
     D3D12_DESCRIPTOR_HEAP_DESC descriptorHeapDesc = {};
     descriptorHeapDesc.Type = D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV;


### PR DESCRIPTION
New GPGMM capabilities:

* GPGMM will pre-fetch memory (on a background thread) automatically or by specifying `ALLOCATION_FLAG_ALWAYS_PREFETCH_MEMORY`. I noticed a 20-30% improvement in CPU time after this change.
* Added built-in allocation leak detection that is always enabled by default for debug builds. Because so, device based leak detection was moved behind a build flag.
* Memory is always recycled by default now, but you can disable this behavior by specifying `ALLOCATOR_FLAG_ALWAYS_ON_DEMAND` for troubleshooting out-of-memory (OOM) errors.

Enjoy WebNN team!

