### PR TITLE
Upgrade DirectML version to 1.6.0

### DIFF
--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -234,7 +234,7 @@ source_set("webnn_native_sources") {
     ]
 
     include_dirs +=
-        [ "${webnn_root}/third_party/microsoft.ai.directml.1.5.1/include" ]
+        [ "${webnn_root}/third_party/microsoft.ai.directml.1.6.0/include" ]
     if (build_with_chromium) {
       include_dirs += [ "${webnn_dawn_root}/src/dawn/native/dml/deps/src" ]
     } else {
@@ -242,7 +242,7 @@ source_set("webnn_native_sources") {
     }
 
     lib_dirs +=
-        [ "${webnn_root}/third_party/microsoft.ai.directml.1.5.1/bin/x64-win" ]
+        [ "${webnn_root}/third_party/microsoft.ai.directml.1.6.0/bin/x64-win" ]
 
     libs += [
       "dxgi.lib",
@@ -441,7 +441,7 @@ if (webnn_enable_dml) {
   dml_dll = "DirectML.dll"
   os_folder = "x64-win"
   dml_dll_path =
-      "${webnn_root}/third_party/microsoft.ai.directml.1.5.1/bin/${os_folder}"
+      "${webnn_root}/third_party/microsoft.ai.directml.1.6.0/bin/${os_folder}"
   copy("copy_dml_dll") {
     sources = [ "${dml_dll_path}/${dml_dll}" ]
     outputs = [ "$root_out_dir/{{source_file_part}}" ]

--- a/src/webnn_native/dml/deps/script/download_dml.py
+++ b/src/webnn_native/dml/deps/script/download_dml.py
@@ -23,7 +23,7 @@ import json
 
 dml_feed_url = 'https://api.nuget.org/v3/index.json'
 dml_resource_id = 'microsoft.ai.directml'
-dml_resource_version = '1.5.1'
+dml_resource_version = '1.6.0'
 
 dependency_dir = '../../../../../third_party'
 dml_bin_path = f'{dependency_dir}/{dml_resource_id}.{dml_resource_version}/bin/x64-win/'


### PR DESCRIPTION
I tried to upgrade to 1.8.0 or 1.7.0, but encounter some issues: some Conv2d end2end case will get wrong result value.
```
[  FAILED  ] Conv2dTests.FusedDepthwiseConv2dDefault
[  FAILED  ] Conv2dTests.FusedDepthwiseConv2dNchwOhwi
[  FAILED  ] Conv2dTests.DepthwiseConv2dWithNchwOihw
```
So I can only upgrade to [1.6.0 ](https://github.com/microsoft/DirectML/blob/master/Releases.md#directml-160)([DML_FEATURE_LEVEL_4_0](https://docs.microsoft.com/en-us/windows/ai/directml/dml-feature-level-history#dml_feature_level_4_0)). I will also raise an issue to DirectML repo. @fujunwei @BruceDai
