### PR TITLE
XNNPACK backend supports subgraph API

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -62,7 +62,7 @@ deps = {
     'url': '{github_git}/oneapi-src/oneDNN.git@4a129541fd4e67e6897072186ea2817a3154eddd',
   },
   'third_party/XNNPACK': {
-    'url': '{github_git}/google/XNNPACK.git@60fc61373f21f0ad3164cc719de464f4b787dc04'
+    'url': '{github_git}/google/XNNPACK.git@a9c0465458e185d8189f483b1bdd8965a3341838'
   },
   'third_party/onnxruntime': {
     'url': '{github_git}/microsoft/onnxruntime.git@0d9030e79888d1d5828730b254fedc53c7b640c1',

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Currently "cpu", "gpu" and "default" are supported, more devices are to be suppo
 
 **Notes**:
  * For OpenVINO backend, please [install 2021.4 version](https://docs.openvinotoolkit.org/2021.4/openvino_docs_install_guides_installing_openvino_linux.html#install-openvino) and [set the environment variables](https://docs.openvinotoolkit.org/2021.4/openvino_docs_install_guides_installing_openvino_linux.html#set-the-environment-variables) before running the end2end tests.
- * The current implementation of XNNPACK, oneDNN and MLAS backends is mainly for the investigation of WebNN [Operation Level Execution
+ * The current implementation of oneDNN and MLAS backends is mainly for the investigation of WebNN [Operation Level Execution
 ](https://webmachinelearning.github.io/webnn/#usecase-op-level-exec) use case. So only a limited set of tests (such as of conv2d) is expected to pass.
 
 ### Run examples

--- a/src/tests/end2end/SplitTests.cpp
+++ b/src/tests/end2end/SplitTests.cpp
@@ -54,24 +54,29 @@ class SplitTests : public WebnnTest {
     }
 };
 
-TEST_F(SplitTests, SplitByDefault) {
+TEST_F(SplitTests, SplitEvenByDefault) {
     testSplit({6}, {1, 2, 3, 4, 5, 6}, {3},
               {
                   {{2}, {1, 2}},
                   {{2}, {3, 4}},
                   {{2}, {5, 6}},
               });
+}
 
+TEST_F(SplitTests, SplitByDefault) {
     testSplit({6}, {1, 2, 3, 4, 5, 6}, {2, 4}, {{{2}, {1, 2}}, {{4}, {3, 4, 5, 6}}});
 }
 
-TEST_F(SplitTests, SplitOneDimension) {
+TEST_F(SplitTests, SplitEvenOneDimension) {
     testSplit({2, 6}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {2},
               {
                   {{2, 3}, {1, 2, 3, 7, 8, 9}},
                   {{2, 3}, {4, 5, 6, 10, 11, 12}},
               },
               1);
+}
+
+TEST_F(SplitTests, SplitOneDimension) {
     testSplit({2, 6}, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}, {2, 4},
               {
                   {{2, 2}, {1, 2, 7, 8}},

--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -303,6 +303,8 @@ source_set("webnn_native_sources") {
 
   if (webnn_enable_xnnpack) {
     sources += [
+      "xnnpack/BackendXNN.cpp",
+      "xnnpack/BackendXNN.h",
       "xnnpack/ContextXNN.cpp",
       "xnnpack/ContextXNN.h",
       "xnnpack/GraphXNN.cpp",

--- a/src/webnn_native/Instance.cpp
+++ b/src/webnn_native/Instance.cpp
@@ -53,6 +53,11 @@ namespace webnn_native {
         BackendConnection* Connect(InstanceBase* instance);
     }
 #endif  // defined(WEBNN_ENABLE_BACKEND_MLAS)
+#if defined(WEBNN_ENABLE_BACKEND_XNNPACK)
+    namespace xnnpack {
+        BackendConnection* Connect(InstanceBase* instance);
+    }
+#endif  // defined(WEBNN_ENABLE_BACKEND_XNNPACK)
 
     namespace {
 
@@ -73,6 +78,9 @@ namespace webnn_native {
 #if defined(WEBNN_ENABLE_BACKEND_MLAS)
             enabledBackends.set(wnn::BackendType::MLAS);
 #endif  // defined(WEBNN_ENABLE_BACKEND_MLAS)
+#if defined(WEBNN_ENABLE_BACKEND_XNNPACK)
+            enabledBackends.set(wnn::BackendType::XNNPACK);
+#endif  // defined(WEBNN_ENABLE_BACKEND_XNNPACK)
             return enabledBackends;
         }
 
@@ -137,6 +145,12 @@ namespace webnn_native {
                 break;
 #endif  // defined(WEBNN_ENABLE_BACKEND_MLAS)
 
+#if defined(WEBNN_ENABLE_BACKEND_XNNPACK)
+            case wnn::BackendType::XNNPACK:
+                Register(xnnpack::Connect(this), wnn::BackendType::XNNPACK);
+                break;
+#endif  // defined(WEBNN_ENABLE_BACKEND_XNNPACK)
+
             default:
                 UNREACHABLE();
         }
@@ -156,6 +170,8 @@ namespace webnn_native {
             return mBackends[wnn::BackendType::OneDNN]->CreateContext(options);
         } else if (mBackends.find(wnn::BackendType::MLAS) != mBackends.end()) {
             return mBackends[wnn::BackendType::MLAS]->CreateContext(options);
+        } else if (mBackends.find(wnn::BackendType::XNNPACK) != mBackends.end()) {
+            return mBackends[wnn::BackendType::XNNPACK]->CreateContext(options);
         }
         UNREACHABLE();
         return nullptr;

--- a/src/webnn_native/WebnnNative.cpp
+++ b/src/webnn_native/WebnnNative.cpp
@@ -31,7 +31,7 @@ namespace webnn_native {
     namespace {
 
         void DumpMemoryLeaks() {
-#if defined(_WIN32) && defined(_DEBUG)
+#if 0
             // Send all reports to STDOUT.
             _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
             _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);

--- a/src/webnn_native/WebnnNative.cpp
+++ b/src/webnn_native/WebnnNative.cpp
@@ -31,7 +31,7 @@ namespace webnn_native {
     namespace {
 
         void DumpMemoryLeaks() {
-#if 0
+#if defined(_WIN32) && defined(_DEBUG)
             // Send all reports to STDOUT.
             _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
             _CrtSetReportFile(_CRT_WARN, _CRTDBG_FILE_STDOUT);

--- a/src/webnn_native/xnnpack/BackendXNN.cpp
+++ b/src/webnn_native/xnnpack/BackendXNN.cpp
@@ -1,0 +1,56 @@
+// Copyright 2022 The Dawn Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "webnn_native/xnnpack/BackendXNN.h"
+
+#include "common/Log.h"
+#include "webnn_native/Instance.h"
+#include "webnn_native/xnnpack/ContextXNN.h"
+
+namespace webnn_native::xnnpack {
+
+    Backend::Backend(InstanceBase* instance)
+        : BackendConnection(instance, wnn::BackendType::XNNPACK) {
+    }
+
+    MaybeError Backend::Initialize() {
+        return {};
+    }
+
+    ContextBase* Backend::CreateContext(ContextOptions const* options) {
+        if (options->devicePreference == wnn::DevicePreference::Gpu) {
+            dawn::ErrorLog() << "XNNPACK backend only supports CPU device.";
+            return nullptr;
+        }
+        Ref<ContextBase> context = AcquireRef(new Context(options));
+        xnn_status status = reinterpret_cast<Context*>(context.Get())->Init();
+        if (status != xnn_status_success) {
+            dawn::ErrorLog() << "Failed to init XNNPACK:" << status;
+            return nullptr;
+        }
+        return context.Detach();
+    }
+
+    BackendConnection* Connect(InstanceBase* instance) {
+        Backend* backend = new Backend(instance);
+
+        if (instance->ConsumedError(backend->Initialize())) {
+            delete backend;
+            return nullptr;
+        }
+
+        return backend;
+    }
+
+}  // namespace webnn_native::xnnpack

--- a/src/webnn_native/xnnpack/BackendXNN.h
+++ b/src/webnn_native/xnnpack/BackendXNN.h
@@ -1,4 +1,4 @@
-// Copyright 2021 The WebNN-native Authors
+// Copyright 2022 The Dawn Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,30 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef WEBNN_NATIVE_XNNPACK_CONTEXT_XNN_H_
-#define WEBNN_NATIVE_XNNPACK_CONTEXT_XNN_H_
+#ifndef WEBNN_NATIVE_XNNPACK_BACKENDXNN_H_
+#define WEBNN_NATIVE_XNNPACK_BACKENDXNN_H_
 
+#include "webnn_native/BackendConnection.h"
 #include "webnn_native/Context.h"
+#include "webnn_native/Error.h"
 
-#include <xnnpack.h>
+#include <memory>
 
 namespace webnn_native::xnnpack {
 
-    class Context : public ContextBase {
+    class Backend : public BackendConnection {
       public:
-        explicit Context(ContextOptions const* options);
-        ~Context() override;
+        Backend(InstanceBase* instance);
 
-        xnn_status Init();
-
-        pthreadpool_t GetThreadpool();
-
-      private:
-        GraphBase* CreateGraphImpl() override;
-
-        pthreadpool_t mThreadpool;
+        MaybeError Initialize();
+        ContextBase* CreateContext(ContextOptions const* options = nullptr) override;
     };
 
 }  // namespace webnn_native::xnnpack
 
-#endif  // WEBNN_NATIVE_XNNPACK_CONTEXT_XNN_H_
+#endif  // WEBNN_NATIVE_XNNPACK_BACKENDXNN_H_

--- a/src/webnn_native/xnnpack/ContextXNN.cpp
+++ b/src/webnn_native/xnnpack/ContextXNN.cpp
@@ -22,17 +22,7 @@
 
 namespace webnn_native::xnnpack {
 
-    ContextBase* Create() {
-        Ref<ContextBase> context = AcquireRef(new Context());
-        xnn_status status = reinterpret_cast<Context*>(context.Get())->Init();
-        if (status != xnn_status_success) {
-            dawn::ErrorLog() << "Failed to init XNNPack:" << status;
-            return nullptr;
-        }
-        return context.Detach();
-    }
-
-    Context::Context() {
+    Context::Context(ContextOptions const* options) {
     }
 
     Context::~Context() {

--- a/src/webnn_native/xnnpack/GraphXNN.cpp
+++ b/src/webnn_native/xnnpack/GraphXNN.cpp
@@ -215,6 +215,15 @@ namespace webnn_native { namespace xnnpack {
                 XNN_TRY(xnn_define_subtract(subgraph, outputMin, outputMax, input0Id, input1Id,
                                             outputId, 0));
                 break;
+            case op::BinaryOpType::kMatMul:
+                if (input1Operand->Shape().size() != 2) {
+                    dawn::ErrorLog() << "XNNPACK backend only support 2D operand b of matmul.";
+                    return xnn_status_invalid_parameter;
+                }
+                XNN_TRY(xnn_define_fully_connected(subgraph, outputMin, outputMax, input0Id,
+                                                   input1Id, XNN_INVALID_VALUE_ID, outputId,
+                                                   XNN_FLAG_TRANSPOSE_WEIGHTS));
+                break;
             default:
                 dawn::ErrorLog() << "XNNPACK backend doesn't support unary op "
                                  << static_cast<int>(binary->GetType());

--- a/src/webnn_native/xnnpack/GraphXNN.cpp
+++ b/src/webnn_native/xnnpack/GraphXNN.cpp
@@ -76,7 +76,7 @@ const char* xnn_status2str(xnn_status v) {
             COMPLAIN_XNN_ERROR_AND_RETURN_DAWN_ERROR(#f, s_); \
     } while (0)
 
-namespace webnn_native { namespace xnnpack {
+namespace webnn_native::xnnpack {
 
     namespace {
         xnn_status GetXnnDataType(wnn::OperandType operandType, xnn_datatype& xnnDataType) {
@@ -772,4 +772,4 @@ namespace webnn_native { namespace xnnpack {
         return {};
     }
 
-}}  // namespace webnn_native::xnnpack
+}  // namespace webnn_native::xnnpack

--- a/src/webnn_native/xnnpack/GraphXNN.h
+++ b/src/webnn_native/xnnpack/GraphXNN.h
@@ -97,8 +97,8 @@ namespace webnn_native::xnnpack {
         std::map<std::string, uint32_t> mExternalOutputs;
 
         // For graph building
-        std::vector<const OperandBase*> mOperandsToBuild;
-        std::map<const OperandBase*, std::shared_ptr<OperandInfo>> mOperandInfoMap;
+        std::vector<const OperatorBase*> mOperandsToBuild;
+        std::map<const OperatorBase*, std::shared_ptr<OperandInfo>> mOperandInfoMap;
     };
 
 }  // namespace webnn_native::xnnpack

--- a/src/webnn_native/xnnpack/GraphXNN.h
+++ b/src/webnn_native/xnnpack/GraphXNN.h
@@ -33,6 +33,7 @@
 #include "webnn_native/ops/Pad.h"
 #include "webnn_native/ops/Pool2d.h"
 #include "webnn_native/ops/Reshape.h"
+#include "webnn_native/ops/Split.h"
 #include "webnn_native/ops/Transpose.h"
 #include "webnn_native/ops/Unary.h"
 #include "webnn_native/xnnpack/ContextXNN.h"
@@ -55,6 +56,7 @@ namespace webnn_native { namespace xnnpack {
         virtual MaybeError AddPad(const op::Pad* pad) override;
         virtual MaybeError AddPool2d(const op::Pool2d* pool2d) override;
         virtual MaybeError AddReshape(const op::Reshape* reshape) override;
+        virtual MaybeError AddSplit(const op::Split* split) override;
         virtual MaybeError AddUnary(const op::Unary* unary) override;
         virtual MaybeError Finish() override;
 
@@ -78,6 +80,7 @@ namespace webnn_native { namespace xnnpack {
         xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Pad* pad);
         xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Pool2d* pool2d);
         xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Reshape* reshape);
+        xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Split* split);
         xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Unary* unary);
 
         enum OperatorType {
@@ -91,6 +94,7 @@ namespace webnn_native { namespace xnnpack {
             Pad,
             Pool2d,
             Reshape,
+            Split,
             Unary
         };
         struct OperatorInfo {

--- a/src/webnn_native/xnnpack/GraphXNN.h
+++ b/src/webnn_native/xnnpack/GraphXNN.h
@@ -39,7 +39,7 @@
 #include "webnn_native/ops/Unary.h"
 #include "webnn_native/xnnpack/ContextXNN.h"
 
-namespace webnn_native { namespace xnnpack {
+namespace webnn_native::xnnpack {
 
     class Graph : public GraphBase {
       public:
@@ -119,6 +119,6 @@ namespace webnn_native { namespace xnnpack {
         xnn_runtime_t mRuntime;
     };
 
-}}  // namespace webnn_native::xnnpack
+}  // namespace webnn_native::xnnpack
 
 #endif  // WEBNN_NATIVE_XNNPACK_GRAPH_XNN_H_

--- a/src/webnn_native/xnnpack/GraphXNN.h
+++ b/src/webnn_native/xnnpack/GraphXNN.h
@@ -34,6 +34,7 @@
 #include "webnn_native/ops/Pool2d.h"
 #include "webnn_native/ops/Reshape.h"
 #include "webnn_native/ops/Split.h"
+#include "webnn_native/ops/Squeeze.h"
 #include "webnn_native/ops/Transpose.h"
 #include "webnn_native/ops/Unary.h"
 #include "webnn_native/xnnpack/ContextXNN.h"
@@ -57,6 +58,7 @@ namespace webnn_native { namespace xnnpack {
         virtual MaybeError AddPool2d(const op::Pool2d* pool2d) override;
         virtual MaybeError AddReshape(const op::Reshape* reshape) override;
         virtual MaybeError AddSplit(const op::Split* split) override;
+        virtual MaybeError AddSqueeze(const op::Squeeze* squeeze) override;
         virtual MaybeError AddUnary(const op::Unary* unary) override;
         virtual MaybeError Finish() override;
 
@@ -81,6 +83,7 @@ namespace webnn_native { namespace xnnpack {
         xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Pool2d* pool2d);
         xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Reshape* reshape);
         xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Split* split);
+        xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Squeeze* squeeze);
         xnn_status DefineXnnNode(xnn_subgraph_t subgraph, const op::Unary* unary);
 
         enum OperatorType {
@@ -95,6 +98,7 @@ namespace webnn_native { namespace xnnpack {
             Pool2d,
             Reshape,
             Split,
+            Squeeze,
             Unary
         };
         struct OperatorInfo {

--- a/webnn.json
+++ b/webnn.json
@@ -73,7 +73,8 @@
         {"value": 1, "name": "DirectML"},
         {"value": 2, "name": "OpenVINO"},
         {"value": 3, "name": "OneDNN"},
-        {"value": 4, "name": "MLAS"}
+        {"value": 4, "name": "MLAS"},
+        {"value": 5, "name": "XNNPACK"}
     ]
   },
   "error type": {


### PR DESCRIPTION
XNNPACK subgraph API is used by [TFLite XNNPACK delegate](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/delegates/xnnpack) for graph level optimization and execution with good performance.

This PR updates WebNN-native's XNNPACK backend to support subgraph API with 27 ops support
* binary including add, sub, mul, div, max, min
* clamp
* concat (only support concatenation of up to 4 inputs)
* conv2d (only support nhwc layout)
* gemm (only support constant weights)
* matmul (only support 2d operand b)
* pad
* pool2d: average and max (only support nhwc layout)
* reshape
* split (only support even split up to 4 outputs)
* squeeze
* unary including abs, ceil, floor, neg
* activations: relu, leakyRelu, hardswish, sigmoid
* softmax

webnn_end2end_tests results:
[  PASSED  ] 103 tests including MobileNetV2Nhwc and SqueezeNetNhwc
267 FAILED TESTS

@fujunwei , PTAL.

This PR also adds constant weights cases in gemm tests, @BruceDai , please also take a look. 