### PR TITLE
[XNNPACK] upgrade to support MSVC static runtime lib

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -62,7 +62,7 @@ deps = {
     'url': '{github_git}/oneapi-src/oneDNN.git@4a129541fd4e67e6897072186ea2817a3154eddd',
   },
   'third_party/XNNPACK': {
-    'url': '{github_git}/google/XNNPACK.git@a9c0465458e185d8189f483b1bdd8965a3341838'
+    'url': '{github_git}/google/XNNPACK.git@42806cdefa7c48247b640a43024040c735d97f29'
   },
   'third_party/onnxruntime': {
     'url': '{github_git}/microsoft/onnxruntime.git@0d9030e79888d1d5828730b254fedc53c7b640c1',

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To build with a backend, please set the corresponding option from following tabl
 Then use `ninja -C out/Release` or `ninja -C out/Debug` to build WebNN-native.
 
 **Notes**
- * To build with XNNPACK backend, please build XNNPACK first, e.g. by [`XNNPACK/scripts/build-local.sh`](https://github.com/google/XNNPACK/blob/master/scripts/build-local.sh).
+ * To build with XNNPACK backend, please build XNNPACK first, e.g. by [`./scripts/build-local.sh`](https://github.com/google/XNNPACK/blob/master/scripts/build-local.sh). For Windows build, it requires supplying -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" to set MSVC static runtime library.
  * To build with oneDNN backend, please build oneDNN first by following the [build from source instructions](https://oneapi-src.github.io/oneDNN/dev_guide_build.html).
  * To build with MLAS backend, please build MLAS (part of ONNX Runtime) first by following the [Build ONNX Runtime for inferencing](https://onnxruntime.ai/docs/build/inferencing.html#build-onnx-runtime-for-inferencing), e.g., by `.\build.bat --config Release --parallel --enable_msvc_static_runtime` for Windows build.
 


### PR DESCRIPTION
No regression of webnn_end2end_tests.

@fujunwei , PTAL.

@BruceDai , this PR is required to build XNNPACK with MSVC static runtime lib on Windows. Please also take a look.

Thanks.