### PR TITLE
[XNNPACK] create pthreadpool per backend

### DIFF
--- a/src/webnn_native/xnnpack/BackendXNN.h
+++ b/src/webnn_native/xnnpack/BackendXNN.h
@@ -19,6 +19,8 @@
 #include "webnn_native/Context.h"
 #include "webnn_native/Error.h"
 
+#include <xnnpack.h>
+
 #include <memory>
 
 namespace webnn_native::xnnpack {
@@ -26,9 +28,13 @@ namespace webnn_native::xnnpack {
     class Backend : public BackendConnection {
       public:
         Backend(InstanceBase* instance);
+        virtual ~Backend() override;
 
         MaybeError Initialize();
         ContextBase* CreateContext(ContextOptions const* options = nullptr) override;
+
+      private:
+        pthreadpool_t mThreadpool;
     };
 
 }  // namespace webnn_native::xnnpack

--- a/src/webnn_native/xnnpack/ContextXNN.cpp
+++ b/src/webnn_native/xnnpack/ContextXNN.cpp
@@ -14,43 +14,13 @@
 
 #include "webnn_native/xnnpack/ContextXNN.h"
 
-#include <thread>
-
 #include "common/Log.h"
 #include "common/RefCounted.h"
 #include "webnn_native/xnnpack/GraphXNN.h"
 
 namespace webnn_native::xnnpack {
 
-    Context::Context(ContextOptions const* options) {
-    }
-
-    Context::~Context() {
-        xnn_status status = xnn_deinitialize();
-        if (status != xnn_status_success) {
-            dawn::ErrorLog() << "xnn_deinitialize failed: " << status;
-            return;
-        }
-        if (mThreadpool != NULL) {
-            pthreadpool_destroy(mThreadpool);
-        }
-    }
-
-    xnn_status Context::Init() {
-        xnn_status status = xnn_initialize(NULL);
-        if (status != xnn_status_success) {
-            dawn::ErrorLog() << "xnn_initialize failed: " << status;
-            return status;
-        }
-        // Create a thread pool with as half of the logical processors in the system.
-        mThreadpool = pthreadpool_create(std::thread::hardware_concurrency() / 2);
-        if (mThreadpool == NULL) {
-            dawn::ErrorLog() << "pthreadpool_create failed";
-            return xnn_status_out_of_memory;
-        }
-        dawn::InfoLog() << "XNNPACK backend thread numbers: "
-                        << pthreadpool_get_threads_count(mThreadpool);
-        return xnn_status_success;
+    Context::Context(pthreadpool_t threadpool) : mThreadpool(threadpool) {
     }
 
     pthreadpool_t Context::GetThreadpool() {

--- a/src/webnn_native/xnnpack/ContextXNN.h
+++ b/src/webnn_native/xnnpack/ContextXNN.h
@@ -23,10 +23,8 @@ namespace webnn_native::xnnpack {
 
     class Context : public ContextBase {
       public:
-        explicit Context(ContextOptions const* options);
-        ~Context() override;
-
-        xnn_status Init();
+        explicit Context(pthreadpool_t threadpool);
+        ~Context() override = default;
 
         pthreadpool_t GetThreadpool();
 


### PR DESCRIPTION
The pthreadpool should be created per backend instead of per context. This PR fix it.

@fujunwei @Honry , PTAL. Thanks.