### PR TITLE
Fix residency management leak when device destructs.

### DIFF
--- a/src/webnn_native/dml/deps/src/device.h
+++ b/src/webnn_native/dml/deps/src/device.h
@@ -73,8 +73,7 @@ namespace pydml
         Microsoft::WRL::ComPtr<ID3D12CommandAllocator> m_commandAllocator;
         Microsoft::WRL::ComPtr<ID3D12GraphicsCommandList> m_commandList;
         Microsoft::WRL::ComPtr<gpgmm::d3d12::ResourceAllocator> m_resourceAllocator;
-            
-        gpgmm::d3d12::ResidencyManager* m_residencyManager = nullptr; // WeakPtr since it is owned by m_resourceAllocator
+        Microsoft::WRL::ComPtr<gpgmm::d3d12::ResidencyManager> m_residencyManager;
 
         // GPU- and CPU-visible descriptor heaps used for ClearUnorderedAccessView
         Microsoft::WRL::ComPtr<ID3D12DescriptorHeap> m_clearUavDescriptorHeapGpu;


### PR DESCRIPTION
Device held a raw reference to a returned ref-counted COM object which causes it to leak because Release() will never be automaically called upon device destruction.

This fixes the issue by making it use a COM reference instead, like other D3D12 created objects.