### PR TITLE
[XNNPACK] optimize the compute performance

### DIFF
--- a/src/webnn_native/NamedInputs.h
+++ b/src/webnn_native/NamedInputs.h
@@ -15,9 +15,9 @@
 #ifndef WEBNN_NATIVE_NAMED_INPUTS_H_
 #define WEBNN_NATIVE_NAMED_INPUTS_H_
 
-#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 #include "common/Log.h"
 #include "webnn_native/webnn_platform.h"
@@ -78,7 +78,7 @@ namespace webnn_native {
         }
 
         // Other methods
-        const std::map<std::string, Input>& GetRecords() const {
+        const std::unordered_map<std::string, Input>& GetRecords() const {
             return mInputs;
         }
 
@@ -88,7 +88,7 @@ namespace webnn_native {
         std::vector<std::unique_ptr<char>> mInputsBuffer;
         std::vector<std::vector<int32_t>> mInputsDimensions;
 
-        std::map<std::string, Input> mInputs;
+        std::unordered_map<std::string, Input> mInputs;
     };
 
 }  // namespace webnn_native

--- a/src/webnn_native/NamedOutputs.h
+++ b/src/webnn_native/NamedOutputs.h
@@ -15,9 +15,9 @@
 #ifndef WEBNN_NATIVE_NAMED_OUTPUTS_H_
 #define WEBNN_NATIVE_NAMED_OUTPUTS_H_
 
-#include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common/RefCounted.h"
@@ -76,7 +76,7 @@ namespace webnn_native {
         }
 
         // Other methods
-        const std::map<std::string, Resource>& GetRecords() const {
+        const std::unordered_map<std::string, Resource>& GetRecords() const {
             return mOutputs;
         }
 
@@ -85,7 +85,7 @@ namespace webnn_native {
         // the same size memory to hold the result from GraphComputeCmd.
         std::vector<std::unique_ptr<char>> mOutputsBuffer;
 
-        std::map<std::string, Resource> mOutputs;
+        std::unordered_map<std::string, Resource> mOutputs;
     };
 
 }  // namespace webnn_native

--- a/src/webnn_native/xnnpack/BackendXNN.cpp
+++ b/src/webnn_native/xnnpack/BackendXNN.cpp
@@ -49,7 +49,7 @@ namespace webnn_native::xnnpack {
             dawn::ErrorLog() << "pthreadpool_create failed";
             return DAWN_INTERNAL_ERROR("Failed to create thread pool.");
         }
-        dawn::InfoLog() << "backend XNNPACK backend thread numbers: "
+        dawn::InfoLog() << "XNNPACK backend thread numbers: "
                         << pthreadpool_get_threads_count(mThreadpool);
         return {};
     }

--- a/src/webnn_native/xnnpack/GraphXNN.cpp
+++ b/src/webnn_native/xnnpack/GraphXNN.cpp
@@ -89,7 +89,12 @@ namespace webnn_native::xnnpack {
         }
     }  // anonymous namespace
 
-    Graph::Graph(Context* context) : GraphBase(context), mExternalId(0), mRuntime(nullptr) {
+    Graph::Graph(Context* context)
+        : GraphBase(context),
+          mExternalId(0),
+          mRuntime(nullptr),
+          mNamedInputs(nullptr),
+          mNamedOutputs(nullptr) {
     }
 
     Graph::~Graph() {
@@ -99,14 +104,16 @@ namespace webnn_native::xnnpack {
         mOperators.push_back({OperatorType::Input, input});
         uint32_t inputId = mExternalId++;
         mInputs.insert(std::make_pair(input->PrimaryOutput(), inputId));
-        mExternals.insert(std::make_pair(input->GetName(), inputId));
+        xnn_external_value externalValue = {inputId, nullptr};
+        mExternals.insert(std::make_pair(input->GetName(), externalValue));
         return {};
     }
 
     MaybeError Graph::AddOutput(std::string_view name, const OperandBase* op) {
         uint32_t outputId = mExternalId++;
         mOutputs.insert(std::make_pair(op, outputId));
-        mExternals.insert(std::make_pair(name, outputId));
+        xnn_external_value externalValue = {outputId, nullptr};
+        mExternals.insert(std::make_pair(name, externalValue));
         return {};
     }
 
@@ -743,30 +750,43 @@ namespace webnn_native::xnnpack {
     }
 
     MaybeError Graph::ComputeImpl(NamedInputsBase* inputs, NamedOutputsBase* outputs) {
-        std::vector<xnn_external_value> externalValues;
-        for (auto& input : inputs->GetRecords()) {
-            if (mExternals.find(input.first) == mExternals.end()) {
-                return DAWN_VALIDATION_ERROR("Invalid input.");
+        if (mNamedInputs != inputs || mNamedOutputs != outputs) {
+            bool anyPointersChanged = false;
+            for (auto& input : inputs->GetRecords()) {
+                if (mExternals.find(input.first) == mExternals.end()) {
+                    return DAWN_VALIDATION_ERROR("Invalid input.");
+                }
+                void* data = static_cast<int8_t*>(input.second.resource.arrayBufferView.buffer) +
+                             input.second.resource.arrayBufferView.byteOffset;
+                if (mExternals[input.first].data != data) {
+                    mExternals[input.first].data = data;
+                    anyPointersChanged = true;
+                }
             }
-            xnn_external_value value = {};
-            value.id = mExternals.at(input.first);
-            value.data = static_cast<int8_t*>(input.second.resource.arrayBufferView.buffer) +
-                         input.second.resource.arrayBufferView.byteOffset;
-            externalValues.push_back(value);
+            mNamedInputs = inputs;
+
+            for (auto& output : outputs->GetRecords()) {
+                if (mExternals.find(output.first) == mExternals.end()) {
+                    return DAWN_VALIDATION_ERROR("Invalid output.");
+                }
+                void* data = static_cast<int8_t*>(output.second.arrayBufferView.buffer) +
+                             output.second.arrayBufferView.byteOffset;
+                if (mExternals[output.first].data != data) {
+                    mExternals[output.first].data = data;
+                    anyPointersChanged = true;
+                }
+            }
+            mNamedOutputs = outputs;
+
+            if (anyPointersChanged) {
+                std::vector<xnn_external_value> externalValues;
+                for (auto& iterator : mExternals) {
+                    externalValues.push_back(iterator.second);
+                }
+                DAWN_TRY(xnn_setup_runtime(mRuntime, externalValues.size(), externalValues.data()));
+            }
         }
 
-        for (auto& output : outputs->GetRecords()) {
-            if (mExternals.find(output.first) == mExternals.end()) {
-                return DAWN_VALIDATION_ERROR("Invalid output.");
-            }
-            xnn_external_value value = {};
-            value.id = mExternals.at(output.first);
-            value.data = static_cast<int8_t*>(output.second.arrayBufferView.buffer) +
-                         output.second.arrayBufferView.byteOffset;
-            externalValues.push_back(value);
-        }
-
-        DAWN_TRY(xnn_setup_runtime(mRuntime, externalValues.size(), externalValues.data()));
         DAWN_TRY(xnn_invoke_runtime(mRuntime));
 
         return {};

--- a/src/webnn_native/xnnpack/GraphXNN.cpp
+++ b/src/webnn_native/xnnpack/GraphXNN.cpp
@@ -753,9 +753,8 @@ namespace webnn_native::xnnpack {
         if (mNamedInputs != inputs || mNamedOutputs != outputs) {
             bool anyPointersChanged = false;
             for (auto& input : inputs->GetRecords()) {
-                if (mExternals.find(input.first) == mExternals.end()) {
-                    return DAWN_VALIDATION_ERROR("Invalid input.");
-                }
+                DAWN_INVALID_IF(mExternals.find(input.first) == mExternals.end(),
+                                "Invalid inputs.");
                 void* data = static_cast<int8_t*>(input.second.resource.arrayBufferView.buffer) +
                              input.second.resource.arrayBufferView.byteOffset;
                 if (mExternals[input.first].data != data) {
@@ -766,9 +765,8 @@ namespace webnn_native::xnnpack {
             mNamedInputs = inputs;
 
             for (auto& output : outputs->GetRecords()) {
-                if (mExternals.find(output.first) == mExternals.end()) {
-                    return DAWN_VALIDATION_ERROR("Invalid output.");
-                }
+                DAWN_INVALID_IF(mExternals.find(output.first) == mExternals.end(),
+                                "Invalid outputs.");
                 void* data = static_cast<int8_t*>(output.second.arrayBufferView.buffer) +
                              output.second.arrayBufferView.byteOffset;
                 if (mExternals[output.first].data != data) {

--- a/src/webnn_native/xnnpack/GraphXNN.h
+++ b/src/webnn_native/xnnpack/GraphXNN.h
@@ -114,9 +114,11 @@ namespace webnn_native::xnnpack {
         uint32_t mExternalId;
 
         std::vector<std::unique_ptr<char>> mBuffers;
-        std::map<std::string, uint32_t> mExternals;
+        std::map<std::string, xnn_external_value> mExternals;
 
         xnn_runtime_t mRuntime;
+        NamedInputsBase* mNamedInputs;
+        NamedOutputsBase* mNamedOutputs;
     };
 
 }  // namespace webnn_native::xnnpack

--- a/src/webnn_native/xnnpack/GraphXNN.h
+++ b/src/webnn_native/xnnpack/GraphXNN.h
@@ -15,8 +15,7 @@
 #ifndef WEBNN_NATIVE_XNNPACK_GRAPH_XNN_H_
 #define WEBNN_NATIVE_XNNPACK_GRAPH_XNN_H_
 
-#include <map>
-#include <set>
+#include <unordered_map>
 
 #include <xnnpack.h>
 
@@ -108,13 +107,13 @@ namespace webnn_native::xnnpack {
             const OperatorBase* op;
         };
         std::vector<OperatorInfo> mOperators;
-        std::map<const OperandBase*, uint32_t> mOperands;
-        std::map<const OperandBase*, uint32_t> mInputs;
-        std::map<const OperandBase*, uint32_t> mOutputs;
+        std::unordered_map<const OperandBase*, uint32_t> mOperands;
+        std::unordered_map<const OperandBase*, uint32_t> mInputs;
+        std::unordered_map<const OperandBase*, uint32_t> mOutputs;
         uint32_t mExternalId;
 
         std::vector<std::unique_ptr<char>> mBuffers;
-        std::map<std::string, xnn_external_value> mExternals;
+        std::unordered_map<std::string, xnn_external_value> mExternals;
 
         xnn_runtime_t mRuntime;
         NamedInputsBase* mNamedInputs;


### PR DESCRIPTION
Only call xnn_setup_runtime when any external pointers change and use unordered_map for inputs and outputs.

@fujunwei @Honry , PTAL. Thanks!