### PR TITLE
[IE] Map the transpose option of Gemm to the parameters of MatMul.

### DIFF
--- a/third_party/openvino/ngraph_c_api/src/ngraph_c_api.cpp
+++ b/third_party/openvino/ngraph_c_api/src/ngraph_c_api.cpp
@@ -316,10 +316,12 @@ IEStatusCode ngraph_leaky_relu(const ngraph_node_t* a,
 
 IEStatusCode ngraph_mat_mul(const ngraph_node_t* a,
                             const ngraph_node_t* b,
+                            bool transpose_a,
+                            bool transpose_b,
                             ngraph_node_t** node) {
   TRY_IE_EXCEPTIONS
-  auto matmul = std::make_shared<ngraph::op::v0::MatMul>(a->object, b->object,
-                                                         false, false);
+  auto matmul = std::make_shared<ngraph::op::v0::MatMul>(
+      a->object, b->object, transpose_a, transpose_b);
   CREATE_NODE_AND_CATCH_EXCEPTIONS(matmul, node);
 }
 

--- a/third_party/openvino/ngraph_c_api/src/ngraph_c_api.h
+++ b/third_party/openvino/ngraph_c_api/src/ngraph_c_api.h
@@ -128,6 +128,8 @@ ngraph_sub(const ngraph_node_t* a,
 NGRAPH_C_API(IEStatusCode)
 ngraph_mat_mul(const ngraph_node_t* a,
                const ngraph_node_t* b,
+               bool transpose_a,
+               bool transpose_b,
                ngraph_node_t** node);
 NGRAPH_C_API(IEStatusCode)
 ngraph_leaky_relu(const ngraph_node_t* a,


### PR DESCRIPTION
Add transpose parameters to `ngraph_mat_mul` function and map the transpose option of Gemm (WebNN) to the transpose parameters of MatMul (IE).