### PR TITLE
Upgrade DirectML version to 1.8.2(latest)

### DIFF
--- a/src/webnn_native/BUILD.gn
+++ b/src/webnn_native/BUILD.gn
@@ -234,7 +234,7 @@ source_set("webnn_native_sources") {
     ]
 
     include_dirs +=
-        [ "${webnn_root}/third_party/microsoft.ai.directml.1.6.0/include" ]
+        [ "${webnn_root}/third_party/microsoft.ai.directml.1.8.2/include" ]
     if (build_with_chromium) {
       include_dirs += [ "${webnn_dawn_root}/src/dawn/native/dml/deps/src" ]
     } else {
@@ -242,7 +242,7 @@ source_set("webnn_native_sources") {
     }
 
     lib_dirs +=
-        [ "${webnn_root}/third_party/microsoft.ai.directml.1.6.0/bin/x64-win" ]
+        [ "${webnn_root}/third_party/microsoft.ai.directml.1.8.2/bin/x64-win" ]
 
     libs += [
       "dxgi.lib",
@@ -443,7 +443,7 @@ if (webnn_enable_dml) {
   dml_dll = "DirectML.dll"
   os_folder = "x64-win"
   dml_dll_path =
-      "${webnn_root}/third_party/microsoft.ai.directml.1.6.0/bin/${os_folder}"
+      "${webnn_root}/third_party/microsoft.ai.directml.1.8.2/bin/${os_folder}"
   copy("copy_dml_dll") {
     sources = [ "${dml_dll_path}/${dml_dll}" ]
     outputs = [ "$root_out_dir/{{source_file_part}}" ]

--- a/src/webnn_native/dml/deps/script/download_dml.py
+++ b/src/webnn_native/dml/deps/script/download_dml.py
@@ -23,7 +23,7 @@ import json
 
 dml_feed_url = 'https://api.nuget.org/v3/index.json'
 dml_resource_id = 'microsoft.ai.directml'
-dml_resource_version = '1.6.0'
+dml_resource_version = '1.8.2'
 
 dependency_dir = '../../../../../third_party'
 dml_bin_path = f'{dependency_dir}/{dml_resource_id}.{dml_resource_version}/bin/x64-win/'


### PR DESCRIPTION
With https://github.com/microsoft/DirectML/issues/234 fixed, we can upgrade DML to latest 1.8.2 version now. @huningxin @fujunwei @BruceDai 