### PR TITLE
[Node] avoid creating instance per context

### DIFF
--- a/node/src/Context.cpp
+++ b/node/src/Context.cpp
@@ -15,8 +15,9 @@
 #include "Context.h"
 
 #include <napi.h>
-#include <webnn/webnn_proc.h>
 #include <iostream>
+
+#include "ML.h"
 
 Napi::FunctionReference node::Context::constructor;
 
@@ -68,10 +69,7 @@ namespace node {
             }
         }
 
-        WebnnProcTable backendProcs = webnn_native::GetProcs();
-        webnnProcSetProcs(&backendProcs);
-        instance = std::make_unique<webnn_native::Instance>();
-        mImpl = wnn::Context::Acquire(instance->CreateContext(&options));
+        mImpl = wnn::Context::Acquire(ML::GetInstance()->CreateContext(&options));
         if (!mImpl) {
             Napi::Error::New(info.Env(), "Failed to create Context").ThrowAsJavaScriptException();
             return;

--- a/node/src/Context.h
+++ b/node/src/Context.h
@@ -17,7 +17,6 @@
 
 #include <napi.h>
 #include <webnn/webnn_cpp.h>
-#include <webnn_native/WebnnNative.h>
 
 namespace node {
 
@@ -32,7 +31,6 @@ namespace node {
         wnn::Context GetImpl();
 
       private:
-        std::unique_ptr<webnn_native::Instance> instance;
         wnn::Context mImpl;
     };
 

--- a/node/src/ML.cpp
+++ b/node/src/ML.cpp
@@ -14,6 +14,8 @@
 
 #include "ML.h"
 
+#include <webnn/webnn_proc.h>
+
 #include "Context.h"
 #include "Utils.h"
 
@@ -44,6 +46,17 @@ namespace node {
         constructor.SuppressDestruct();
         exports.Set("ml", func);
         return exports;
+    }
+
+    std::unique_ptr<webnn_native::Instance> ML::gInstance;
+
+    webnn_native::Instance* ML::GetInstance() {
+        if (gInstance == nullptr) {
+            WebnnProcTable backendProcs = webnn_native::GetProcs();
+            webnnProcSetProcs(&backendProcs);
+            gInstance = std::make_unique<webnn_native::Instance>();
+        }
+        return gInstance.get();
     }
 
 }  // namespace node

--- a/node/src/ML.h
+++ b/node/src/ML.h
@@ -16,6 +16,7 @@
 #define NODE_ML_H__
 
 #include <napi.h>
+#include <webnn_native/WebnnNative.h>
 
 namespace node {
 
@@ -27,8 +28,12 @@ namespace node {
         ML(const Napi::CallbackInfo& info);
         ~ML() = default;
 
+        static webnn_native::Instance* GetInstance();
+
       private:
         static Napi::Value CreateContext(const Napi::CallbackInfo& info);
+
+        static std::unique_ptr<webnn_native::Instance> gInstance;
     };
 
 }  // namespace node


### PR DESCRIPTION
There should be only one instance globally. Otherwise there will be duplicated allocations for per instance resources, e.g., the threadpool for XNNPACK backend.

@fujunwei @Honry PTAL. Thanks.
