### PR TITLE
Roll third_party/gpgmm/ c32f9d37f..72f910e8d (229 commits)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -55,7 +55,7 @@ deps = {
   },
   # GPGMM support for fast DML allocation and residency management.
   'third_party/gpgmm': {
-    'url': '{github_git}/intel/gpgmm.git@c32f9d37f1ece0b3a3996aeecd23ae01c763854d',
+    'url': '{github_git}/intel/gpgmm.git@72f910e8dcb0048d84c11f705b96b768b9eee156',
     'condition': 'checkout_win',
   },
   'third_party/oneDNN': {

--- a/build_overrides/gpgmm.gni
+++ b/build_overrides/gpgmm.gni
@@ -21,3 +21,4 @@
 # This file is intentionally empty because WebNN-native uses non-standalone
 # GPGMM and non-standalone GPGMM has no dependencies to override but GN
 # must import a gpgmm.gni file to build without overrides.
+gpgmm_enable_vk = false

--- a/src/webnn/native/dmlx/deps/src/util.h
+++ b/src/webnn/native/dmlx/deps/src/util.h
@@ -118,7 +118,7 @@ struct DmlBufferArrayBinding
 
 inline void UpdateResidencyIfNeeded(gpgmm::d3d12::ResourceAllocation* resource, gpgmm::d3d12::ResidencySet* residencySet){
     if (resource == nullptr) return;
-    resource->UpdateResidency(residencySet);
+    residencySet->Insert(resource->GetMemory());
 }
 
 inline HRESULT CreateResource(


### PR DESCRIPTION
Highlights:
* Heap recycling is now prioritized over pre-allocation when over budget.
* Heap re-sizing is now supported and enabled when under budget.

Breaking changes
* `ResourceAllocation::UpdateResidency` is now depreciated (replaced by `ResidencySet::Insert`).

Fixed:
* Program exit access violation due to trace recording being mistakenly enabled.

@fujunwei @fujunwei 