### PR TITLE
Enable GPU memory trace dump

### DIFF
--- a/build_overrides/webnn_features.gni
+++ b/build_overrides/webnn_features.gni
@@ -40,4 +40,5 @@ declare_args() {
 
   webnn_enable_wire = false
   webnn_enable_gpu_buffer = false
+  webnn_enable_resource_dump = false
 }

--- a/src/webnn/native/BUILD.gn
+++ b/src/webnn/native/BUILD.gn
@@ -247,6 +247,10 @@ source_set("sources") {
     if (build_with_chromium == false) {
       include_dirs += [ "${webnn_root}/third_party/DirectML/Libraries" ]
     }
+
+    if (webnn_enable_resource_dump) {
+      defines = [ "WEBNN_ENABLE_RESOURCE_DUMP" ]
+    }
   }
 
   if (webnn_enable_dml || webnn_enable_dmlx) {

--- a/src/webnn/native/dmlx/deps/src/device.cpp
+++ b/src/webnn/native/dmlx/deps/src/device.cpp
@@ -112,6 +112,13 @@ HRESULT Device::Init()
     allocatorDesc.Device = m_d3d12Device;
     allocatorDesc.IsUMA = arch.UMA;
     allocatorDesc.ResourceHeapTier = options.ResourceHeapTier;
+
+#ifdef WEBNN_ENABLE_RESOURCE_DUMP
+    allocatorDesc.RecordOptions.Flags |= gpgmm::d3d12::ALLOCATOR_RECORD_FLAG_ALL_EVENTS;
+    allocatorDesc.RecordOptions.MinMessageLevel = D3D12_MESSAGE_SEVERITY_MESSAGE;
+    allocatorDesc.RecordOptions.UseDetailedTimingEvents = true;
+#endif
+
     ReturnIfFailed(gpgmm::d3d12::ResourceAllocator::CreateAllocator(allocatorDesc, &m_resourceAllocator, &m_residencyManager));
 
     D3D12_DESCRIPTOR_HEAP_DESC descriptorHeapDesc = {};


### PR DESCRIPTION
How to collect:
1. Add `webnn_enable_resource_dump = true` to `args.gn`.
2. Run any executable (chrome.exe, end2end, etc).
3. Open `gpgmm_event_trace.json` in `chrome://tracing`.

How to analyze:

You basically want `GPU allocation utilization` to be **always 100%** and `GPU memory utilization` to be always **under 100%**. The former means NO allocation is being wasted and the latter means NO memory is being paged-out to the OS. `GPU memory free` reports waste due to fragmentation, this should be small.

How does it work:
GPGMM tracks how much actual resource memory was used. For example, if you create 1GB heap, that contains a 1 byte resource, this will correctly reported as 1B used. OS tools like WPA just report 1GB being used, not very helpful.

@fujunwei @mingmingtasd 