### PR TITLE
Fixed memory error for empty values in GraphIE.cpp AddConstantWithGraph

### DIFF
--- a/src/webnn/native/openvino/GraphIE.cpp
+++ b/src/webnn/native/openvino/GraphIE.cpp
@@ -1165,7 +1165,9 @@ namespace webnn::native::ie {
     MaybeError Graph::AddReshape(const op::Reshape* reshape) {
         auto newShape = reshape->GetNewShape();
         const ngraph_node_t* constantNode =
-            AddConstantWithGraph<int32_t>(precision_e::I32, {newShape.size()}, newShape);
+            newShape.empty()
+                ? AddConstantWithGraph<int32_t>(precision_e::I32, {}, {1})
+                : AddConstantWithGraph<int32_t>(precision_e::I32, {newShape.size()}, newShape);
         auto input = mGraphNodeMap[reshape->Inputs()[0].Get()];
         ngraph_node_t* reshapeNode;
         IEStatusCode status = ngraph_reshape(input, constantNode, &reshapeNode);

--- a/src/webnn/native/ops/Reshape.cpp
+++ b/src/webnn/native/ops/Reshape.cpp
@@ -26,6 +26,10 @@ namespace webnn::native::op {
         }
         int minus1DimIdx = -1;
         bool hasMinus1 = false;
+        // Special case for scalar
+        if (mNewShape.empty()) {
+            mNewShape.push_back(1);
+        }
         std::vector<int32_t> outputShape(mNewShape.size());
         for (size_t i = 0; i < mNewShape.size(); ++i) {
             int32_t dim = mNewShape[i];

--- a/src/webnn/tests/end2end/ReshapeTests.cpp
+++ b/src/webnn/tests/end2end/ReshapeTests.cpp
@@ -24,8 +24,10 @@ class ReshapeTests : public WebnnTest {
         const wnn::Operand b = builder.Reshape(a, newShape.data(), newShape.size());
         const wnn::Graph graph = utils::Build(builder, {{"b", b}});
         ASSERT_TRUE(graph);
-        const std::vector<float> inputData = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
-                                              13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
+        const std::vector inputData =
+            newShape.empty() ? std::vector<float>{1}
+                             : std::vector<float>{1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12,
+                                                  13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24};
         std::vector<float> result(utils::SizeOfShape(expectedShape));
         utils::Compute(graph, {{"a", inputData}}, {{"b", result}});
         EXPECT_TRUE(utils::CheckValue(result, inputData));
@@ -58,4 +60,8 @@ TEST_F(ReshapeTests, ReshapeNegativeDim) {
 
 TEST_F(ReshapeTests, ReshapeNegativeDim1) {
     TestReshape({2, 3, 4}, {-1, 2, 3, 4}, {1, 2, 3, 4});
+}
+
+TEST_F(ReshapeTests, ReshapeZeroDim) {
+    TestReshape({}, {}, {});
 }


### PR DESCRIPTION
Added test case for Reshape 0D tensor and fixed the related bug.