### PR TITLE
Enable PIX Capture for debug builds.

### DIFF
--- a/src/webnn/native/dmlx/GraphDMLX.cpp
+++ b/src/webnn/native/dmlx/GraphDMLX.cpp
@@ -522,7 +522,7 @@ namespace webnn::native::dmlx {
                 gpuPreference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED;
         }
 #    if defined(_DEBUG)
-        mDevice.reset(new ::pydml::Device(useGpu, true, gpuPreference));
+        mDevice.reset(new ::pydml::Device(useGpu, true, true, gpuPreference));
 #    else
         mDevice.reset(new ::pydml::Device(useGpu, false, gpuPreference));
 #    endif

--- a/src/webnn/native/dmlx/deps/src/device.cpp
+++ b/src/webnn/native/dmlx/deps/src/device.cpp
@@ -6,6 +6,8 @@
 
 #include "precomp.h"
 
+#include <DXProgrammableCapture.h>
+
 #pragma warning(push)
 #pragma warning(disable:4238)
 
@@ -23,7 +25,7 @@ ID3D12DescriptorHeap* SVDescriptorHeap::GetDescriptorHeap() const {
     return descriptorHeap.Get();
 }
 
-Device::Device(bool useGpu, bool useDebugLayer, DXGI_GPU_PREFERENCE gpuPreference) : m_useGpu(useGpu), m_useDebugLayer(useDebugLayer), m_gpuPreference(gpuPreference) {}
+Device::Device(bool useGpu, bool useDebugLayer, bool beginCaptureOnStartup, DXGI_GPU_PREFERENCE gpuPreference) : m_useGpu(useGpu), m_useDebugLayer(useDebugLayer), m_beginCaptureOnStartup(beginCaptureOnStartup), m_gpuPreference(gpuPreference) {}
 
 // An adapter called the "Microsoft Basic Render Driver" is always present. This adapter is a render-only device that has no display outputs.
 HRESULT IsWarpAdapter(IDXGIAdapter1* pAdapter, bool* isWarpAdapter) {
@@ -50,6 +52,14 @@ HRESULT Device::Init()
         if (SUCCEEDED(D3D12GetDebugInterface(IID_PPV_ARGS(&debugController))))
         {
             debugController->EnableDebugLayer();
+        }
+    }
+
+    
+    if (m_beginCaptureOnStartup){
+        ComPtr<IDXGraphicsAnalysis> graphicsAnalysis;
+        if (SUCCEEDED(DXGIGetDebugInterface1(0, IID_PPV_ARGS(&graphicsAnalysis)))) {
+            graphicsAnalysis->BeginCapture();
         }
     }
 

--- a/src/webnn/native/dmlx/deps/src/device.h
+++ b/src/webnn/native/dmlx/deps/src/device.h
@@ -21,7 +21,7 @@ namespace pydml
     class Device
     {
     public:
-        explicit Device(bool useGpu = true, bool useDebugLayer = false, DXGI_GPU_PREFERENCE gpuPreference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED);
+        explicit Device(bool useGpu = true, bool useDebugLayer = false, bool beginCaptureOnStartup = false, DXGI_GPU_PREFERENCE gpuPreference = DXGI_GPU_PREFERENCE::DXGI_GPU_PREFERENCE_UNSPECIFIED);
 
         HRESULT Init();
 
@@ -103,6 +103,7 @@ namespace pydml
         bool m_useCpuCustomHeapResources = false;
         bool m_useGpu = true;
         bool m_useDebugLayer = false;
+        bool m_beginCaptureOnStartup = false;
         DXGI_GPU_PREFERENCE m_gpuPreference;
     };
 }


### PR DESCRIPTION
Allows PIX to capture the DML backend for analysis.