### PR TITLE
Remove permissions settings in Auto roll CI by manually configuration.

### DIFF
--- a/.github/workflows/auto_roll_deps.yml
+++ b/.github/workflows/auto_roll_deps.yml
@@ -4,13 +4,8 @@ on:
   workflow_dispatch:
 
   schedule:
-    # Every Monday at 3 am
-    - cron: "0 3 * * 1"
-
-permissions:
-  actions: read/write
-  contents: read
-  pull-requests: write
+    # Every Monday at 12 am
+    - cron: "0 12 * * 1"
 
 jobs:
   deps:

--- a/.github/workflows/build_test_openvino_windows.yml
+++ b/.github/workflows/build_test_openvino_windows.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
+    name: Build, Test OpenVINO (Windows)
     runs-on: windows-2019
     env:
       OPENVINO_VERSION: 2021.4.582


### PR DESCRIPTION
@fujunwei Last configured permissions setting of Auto rolling DEPS CI didn't work, so I removed these settings in this PR.
I just ping @anssiko to help manually configure that.