### PR TITLE
Add job names for checking to auto merge PRs by Auto rolling DEPS CI.

### DIFF
--- a/.github/workflows/build_mlas_windows.yml
+++ b/.github/workflows/build_mlas_windows.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
+    name: Build MLAS backend (Windows)
     runs-on: windows-2019
 
     steps:

--- a/.github/workflows/build_test_dmlx.yml
+++ b/.github/workflows/build_test_dmlx.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
-
+    name: Build, Test DirectMLX backend (Windows)
     runs-on: windows-2019
 
     steps:

--- a/.github/workflows/build_test_onednn_linux.yml
+++ b/.github/workflows/build_test_onednn_linux.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
+    name: Build, Test oneDNN backend (Linux)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_test_onednn_windows.yml
+++ b/.github/workflows/build_test_onednn_windows.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
+    name: Build, Test oneDNN backend (Windows)
     runs-on: windows-2019
 
     steps:

--- a/.github/workflows/build_test_openvino_linux.yml
+++ b/.github/workflows/build_test_openvino_linux.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
+    name: Build, Test OpenVINO backend (Linux)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_test_openvino_windows.yml
+++ b/.github/workflows/build_test_openvino_windows.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
-    name: Build, Test OpenVINO (Windows)
+    name: Build, Test OpenVINO backend (Windows)
     runs-on: windows-2019
     env:
       OPENVINO_VERSION: 2021.4.582

--- a/.github/workflows/build_test_xnnpack_linux.yml
+++ b/.github/workflows/build_test_xnnpack_linux.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
+    name: Build, Test XNNPACK backend (Linux)
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_test_xnnpack_windows.yml
+++ b/.github/workflows/build_test_xnnpack_windows.yml
@@ -5,6 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
+    name: Build, Test XNNPACK backend (Windows)
     runs-on: windows-2019
 
     steps:

--- a/.github/workflows/memory_leak_check_dmlx.yml
+++ b/.github/workflows/memory_leak_check_dmlx.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
 
   job:
-
+    name: Memory leak check DirectMLX backend (Windows)
     runs-on: windows-2019
 
     steps:


### PR DESCRIPTION
Thanks for @anssiko's help of setting "Branch protection rules" for `main` branch, now we can see on PR #295, the `Build, Test OpenVINO (Windows)` CI was configured to check pass before merging auto generated PRs by [Auto rolling DEPS CI](https://github.com/webmachinelearning/webnn-native/actions/workflows/auto_roll_deps.yml). This's an experiment, since there're many decencies,  we need add more CIs to check those auto generated PRs.