### PR TITLE
Enable GPGMM without DEPS.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -55,7 +55,7 @@ deps = {
   },
   # GPGMM support for fast DML allocation and residency management.
   'third_party/gpgmm': {
-    'url': '{github_git}/intel/gpgmm.git@ff03c9a0cea262e534d25257512f2ba2bdb8c2d4',
+    'url': '{github_git}/intel/gpgmm.git@1d74b3f050990563d2a834bd6512d6e82ed2a307',
     'condition': 'checkout_win',
   },
   'third_party/oneDNN': {

--- a/build_overrides/webnn_features.gni
+++ b/build_overrides/webnn_features.gni
@@ -41,4 +41,7 @@ declare_args() {
   webnn_enable_wire = false
   webnn_enable_gpu_buffer = false
   webnn_enable_resource_dump = false
+
+  # Enables the compilation of GPGMM in WebNN without DEPS.
+  webnn_use_min_gpgmm = false
 }

--- a/src/webnn/native/BUILD.gn
+++ b/src/webnn/native/BUILD.gn
@@ -273,7 +273,19 @@ source_set("sources") {
     ]
 
     data_deps += [ ":copy_dml_dll" ]
-    deps += [ "${webnn_gpgmm_dir}/src:gpgmm" ]
+
+    # Use GPGMM MVI to test-against the GMM interface provided by GPGMM with a pass-through implementation.
+    if (webnn_use_min_gpgmm) {
+      include_dirs += [ "${webnn_gpgmm_dir}/src/include/min" ]
+      sources += [
+        "${webnn_gpgmm_dir}/src/include/min/gpgmm.cpp",
+        "${webnn_gpgmm_dir}/src/include/min/gpgmm.h",
+        "${webnn_gpgmm_dir}/src/include/min/gpgmm_d3d12.cpp",
+        "${webnn_gpgmm_dir}/src/include/min/gpgmm_d3d12.h",
+      ]
+    } else {
+      deps += [ "${webnn_gpgmm_dir}/src:gpgmm" ]
+    }
   }
 
   if (webnn_enable_onednn) {

--- a/src/webnn/native/dmlx/deps/src/device.cpp
+++ b/src/webnn/native/dmlx/deps/src/device.cpp
@@ -692,7 +692,7 @@ HRESULT Device::EnsureDescriptorHeapSize(uint32_t requestedSizeInDescriptors)
 
         gpgmm::d3d12::HEAP_DESC heapDesc = {};
         heapDesc.SizeInBytes = newSize * m_d3d12Device->GetDescriptorHandleIncrementSize(D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV);
-        heapDesc.MemorySegment = gpgmm::d3d12::RESIDENCY_SEGMENT_LOCAL;
+        heapDesc.MemorySegmentGroup = DXGI_MEMORY_SEGMENT_GROUP_LOCAL;
 
         ComPtr<gpgmm::d3d12::Heap> descriptorHeap;
         ReturnIfFailed(gpgmm::d3d12::Heap::CreateHeap(heapDesc, m_residencyManager.Get(), createHeapFn,

--- a/src/webnn/native/dmlx/deps/src/device.h
+++ b/src/webnn/native/dmlx/deps/src/device.h
@@ -8,6 +8,8 @@
 
 #include <gpgmm_d3d12.h>
 
+using Microsoft::WRL::ComPtr;
+
 namespace pydml
 {
     class SVDescriptorHeap {


### PR DESCRIPTION
This change adds `webnn_use_min_gpgmm`, which builds WebNN-native using the GPGMM MVI. GPGMM MVI is a self-contained source-only folder which can be whole-copied into another source-tree without using DEPS. GPGMM MVI is a simple pass-through implementation of GPGMM, allowing GPGMM's portable GMM interface to be integrated into a project without requiring the full GMM implementation. Please see /src/include/min/gpgmm_d3d12.h for limitations.