### PR TITLE
Enable GPGMM without requiring DEPS.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -55,7 +55,7 @@ deps = {
   },
   # GPGMM support for fast DML allocation and residency management.
   'third_party/gpgmm': {
-    'url': '{github_git}/intel/gpgmm.git@ff03c9a0cea262e534d25257512f2ba2bdb8c2d4',
+    'url': '{github_git}/intel/gpgmm.git@f972e83bc3ce86941adae7c22f6d2646aa706ea2',
     'condition': 'checkout_win',
   },
   'third_party/oneDNN': {

--- a/build_overrides/webnn_features.gni
+++ b/build_overrides/webnn_features.gni
@@ -41,4 +41,7 @@ declare_args() {
   webnn_enable_wire = false
   webnn_enable_gpu_buffer = false
   webnn_enable_resource_dump = false
+
+  # Enables the compilation of GPGMM in WebNN without DEPS.
+  webnn_use_min_gpgmm = false
 }

--- a/src/webnn/native/BUILD.gn
+++ b/src/webnn/native/BUILD.gn
@@ -273,7 +273,21 @@ source_set("sources") {
     ]
 
     data_deps += [ ":copy_dml_dll" ]
-    deps += [ "${webnn_gpgmm_dir}/src:gpgmm" ]
+
+    # Build the GPGMM MVI which uses the GMM interface provided by GPGMM with a pass-through GMM implementation.
+    if (webnn_use_min_gpgmm) {
+      include_dirs += [ "${webnn_gpgmm_dir}/src/include/min" ]
+      sources += [
+        "${webnn_gpgmm_dir}/src/include/min/gpgmm.cpp",
+        "${webnn_gpgmm_dir}/src/include/min/gpgmm.h",
+        "${webnn_gpgmm_dir}/src/include/min/gpgmm_d3d12.cpp",
+        "${webnn_gpgmm_dir}/src/include/min/gpgmm_d3d12.h",
+      ]
+
+      # Build GPGMM which brings the full GMM implementation.
+    } else {
+      deps += [ "${webnn_gpgmm_dir}/src:gpgmm" ]
+    }
   }
 
   if (webnn_enable_onednn) {

--- a/src/webnn/native/dmlx/deps/src/device.h
+++ b/src/webnn/native/dmlx/deps/src/device.h
@@ -8,6 +8,8 @@
 
 #include <gpgmm_d3d12.h>
 
+using Microsoft::WRL::ComPtr;
+
 namespace pydml
 {
     class SVDescriptorHeap {


### PR DESCRIPTION
Adds build option webnn_use_min_gpgmm, to build using the GPGMM minimum viable implementation (MVI). GPGMM MVI builds a self-contained source folder (src/include/min) which can be whole-copied into another source-tree. GPGMM MVI is a pass-through implementation of GPGMM. Please see /src/include/min/gpgmm_d3d12.h for limitations.